### PR TITLE
Feat: Initial Work TCG

### DIFF
--- a/frontend/src/components/RuleBuilder/Canvas/index.tsx
+++ b/frontend/src/components/RuleBuilder/Canvas/index.tsx
@@ -66,6 +66,7 @@ interface CanvasProps {
   initialNodes?: Node[];
   initialEdges?: Edge[];
   onUpdateNodeInternalsReady?: (updateFn: (nodeId: string) => void) => void;
+  mode?: 'rule-builder' | 'test-case-generate'; 
 }
 
 
@@ -85,6 +86,7 @@ const RuleBuilderCanvas: React.FC<CanvasProps> = ({
   initialNodes,
   initialEdges,
   onUpdateNodeInternalsReady,
+  mode = 'rule-builder',
 }) => {
   const initialDataRef = useRef({ nodes: initialNodes, edges: initialEdges });
   const extractedNestedCountersRef = useRef(false);
@@ -94,13 +96,11 @@ const RuleBuilderCanvas: React.FC<CanvasProps> = ({
     const edges = (initialDataRef.current.edges as Edge[]) || [];
     return { nodes, edges };
   }, []);
-  
-  // Stable derived value for nested data availability
+
   const hasNestedFlows = React.useMemo(() => {
     return nestedCanvasData ? Object.keys(nestedCanvasData).length > 0 : false;
   }, [nestedCanvasData]);
   
-  // Extract counters on mount and when nested flows first become available
   useEffect(() => {
     const { nodes, edges } = getInitialFlow;
     
@@ -169,6 +169,7 @@ const RuleBuilderCanvas: React.FC<CanvasProps> = ({
     onJsonGenerate,
     onCodeGenerate,
     reactFlowInstance: reactFlowInstance as Record<string, unknown> | undefined,
+    mode,
   });
 
   const {

--- a/frontend/src/components/RuleBuilder/Header/index.tsx
+++ b/frontend/src/components/RuleBuilder/Header/index.tsx
@@ -35,6 +35,7 @@ interface HeaderProps {
   isSaving?: boolean;
   disabled?: boolean;
   viewOnly?: boolean;
+  hidePlayControls?: boolean;
 }
 
 const Header: React.FC<HeaderProps> = ({
@@ -51,6 +52,7 @@ const Header: React.FC<HeaderProps> = ({
   isSaving = false,
   disabled = false,
   viewOnly = false,
+  hidePlayControls = false,
 }) => {
   const { hasErrors, getErrorCount } = useValidationContext();
   const navigate = useNavigate();
@@ -82,71 +84,75 @@ const Header: React.FC<HeaderProps> = ({
         </Box>
 
         <ButtonGroup>
-          {!isPlaying ? (
-            <Tooltip title={hasErrors ? 'Fix validation errors before running' : 'Run flow animation'}>
-              <span>
-                <ActionButton
-                  variant="contained"
-                  color="primary"
-                  startIcon={<PlayArrowIcon />}
-                  onClick={onPlayClick}
-                  disabled={isDisabled}
-                  sx={{
-                    minWidth: '100px',
-                  }}
-                >
-                  Play
-                </ActionButton>
-              </span>
-            </Tooltip>
-          ) : (
+          {!hidePlayControls && (
             <>
-              {isPaused ? (
-                <Tooltip title="Resume execution">
-                  <ActionButton
-                    variant="contained"
-                    color="success"
-                    startIcon={<PlayArrowIcon />}
-                    onClick={onResumeClick}
-                    sx={{
-                      minWidth: '100px',
-                    }}
-                  >
-                    Resume
-                  </ActionButton>
+              {!isPlaying ? (
+                <Tooltip title={hasErrors ? 'Fix validation errors before running' : 'Run flow animation'}>
+                  <span>
+                    <ActionButton
+                      variant="contained"
+                      color="primary"
+                      startIcon={<PlayArrowIcon />}
+                      onClick={onPlayClick}
+                      disabled={isDisabled}
+                      sx={{
+                        minWidth: '100px',
+                      }}
+                    >
+                      Play
+                    </ActionButton>
+                  </span>
                 </Tooltip>
               ) : (
-                <Tooltip title="Pause execution">
-                  <ActionButton
-                    variant="contained"
-                    color="warning"
-                    startIcon={<PauseIcon />}
-                    onClick={onPauseClick}
-                    sx={{
-                      minWidth: '100px',
-                    }}
-                  >
-                    Pause
-                  </ActionButton>
-                </Tooltip>
+                <>
+                  {isPaused ? (
+                    <Tooltip title="Resume execution">
+                      <ActionButton
+                        variant="contained"
+                        color="success"
+                        startIcon={<PlayArrowIcon />}
+                        onClick={onResumeClick}
+                        sx={{
+                          minWidth: '100px',
+                        }}
+                      >
+                        Resume
+                      </ActionButton>
+                    </Tooltip>
+                  ) : (
+                    <Tooltip title="Pause execution">
+                      <ActionButton
+                        variant="contained"
+                        color="warning"
+                        startIcon={<PauseIcon />}
+                        onClick={onPauseClick}
+                        sx={{
+                          minWidth: '100px',
+                        }}
+                      >
+                        Pause
+                      </ActionButton>
+                    </Tooltip>
+                  )}
+                  <Tooltip title="Stop and reset">
+                    <ActionButton
+                      variant="contained"
+                      color="error"
+                      startIcon={<StopIcon />}
+                      onClick={onStopClick}
+                      sx={{
+                        minWidth: '100px',
+                      }}
+                    >
+                      Stop
+                    </ActionButton>
+                  </Tooltip>
+                </>
               )}
-              <Tooltip title="Stop and reset">
-                <ActionButton
-                  variant="contained"
-                  color="error"
-                  startIcon={<StopIcon />}
-                  onClick={onStopClick}
-                  sx={{
-                    minWidth: '100px',
-                  }}
-                >
-                  Stop
-                </ActionButton>
-              </Tooltip>
+
+              <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
             </>
           )}
-
-          <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
 
           {!viewOnly && onSave && (
             <>

--- a/frontend/src/components/RuleBuilder/LeftSidebar/index.tsx
+++ b/frontend/src/components/RuleBuilder/LeftSidebar/index.tsx
@@ -31,6 +31,7 @@ interface LeftSidebarProps {
   onToggleCollapse?: () => void;
   hideCustomFunctions?: boolean;
   hideImportNode?: boolean;
+  hideStartEnd?: boolean;
   showGlobalVariables?: boolean;
   allNodes?: Node[];
   edges?: import('@xyflow/react').Edge[];
@@ -44,6 +45,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
   onToggleCollapse,
   hideCustomFunctions = false,
   hideImportNode = false,
+  hideStartEnd = false,
   showGlobalVariables = false,
   allNodes = [],
   edges = [],
@@ -75,7 +77,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
     setActiveTab(newValue);
   };
 
-  const { getNodesToShow, functionNodes } = useNodePalette({ mode, hideCustomFunctions, hideImportNode, apiNodes: nodeTemplates });
+  const { getNodesToShow, functionNodes } = useNodePalette({ mode, hideCustomFunctions, hideImportNode, hideStartEnd, apiNodes: nodeTemplates });
   const { localVars, loopVars, loopContext } = useLocalVariables({ 
     allNodes, 
     edges, 

--- a/frontend/src/components/RuleBuilder/RightSidebar/components/CodeEditorDialog.tsx
+++ b/frontend/src/components/RuleBuilder/RightSidebar/components/CodeEditorDialog.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@mui/material';
+import Editor from '@monaco-editor/react';
+
+interface CodeEditorDialogProps {
+  open: boolean;
+  title: string;
+  value: string;
+  onChange: (value: string) => void;
+  onSave: () => void;
+  onClose: () => void;
+  height?: string;
+}
+
+export const CodeEditorDialog: React.FC<CodeEditorDialogProps> = ({
+  open,
+  title,
+  value,
+  onChange,
+  onSave,
+  onClose,
+  height = '400px',
+}) => {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <Editor
+          height={height}
+          defaultLanguage="typescript"
+          value={value}
+          onChange={(val) => onChange(val || '')}
+          theme="vs-dark"
+          options={{
+            minimap: { enabled: false },
+            fontSize: 14,
+            lineNumbers: 'on',
+            scrollBeyondLastLine: false,
+            automaticLayout: true,
+          }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={onSave} variant="contained" color="primary">
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/RuleBuilder/RightSidebar/components/NodeSections/BeforeAllSection.tsx
+++ b/frontend/src/components/RuleBuilder/RightSidebar/components/NodeSections/BeforeAllSection.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Typography, Button } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+
+interface BeforeAllSectionProps {
+  onEdit: () => void;
+  viewOnly?: boolean;
+}
+
+export const BeforeAllSection: React.FC<BeforeAllSectionProps> = ({ onEdit, viewOnly = false }) => {
+  return (
+    <>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Setup code that runs once before all test cases
+      </Typography>
+      <Button
+        variant="outlined"
+        startIcon={<EditIcon />}
+        onClick={onEdit}
+        fullWidth
+        disabled={viewOnly}
+      >
+        Edit beforeAll Code
+      </Button>
+    </>
+  );
+};

--- a/frontend/src/components/RuleBuilder/RightSidebar/components/NodeSections/BeforeEachSection.tsx
+++ b/frontend/src/components/RuleBuilder/RightSidebar/components/NodeSections/BeforeEachSection.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Typography, Button } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+
+interface BeforeEachSectionProps {
+  onEdit: () => void;
+  viewOnly?: boolean;
+}
+
+export const BeforeEachSection: React.FC<BeforeEachSectionProps> = ({ onEdit, viewOnly = false }) => {
+  return (
+    <>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Setup code that runs before each test case
+      </Typography>
+      <Button
+        variant="outlined"
+        startIcon={<EditIcon />}
+        onClick={onEdit}
+        fullWidth
+        disabled={viewOnly}
+      >
+        Edit beforeEach Code
+      </Button>
+    </>
+  );
+};

--- a/frontend/src/components/RuleBuilder/RightSidebar/components/NodeSections/index.ts
+++ b/frontend/src/components/RuleBuilder/RightSidebar/components/NodeSections/index.ts
@@ -1,0 +1,2 @@
+ export { BeforeEachSection } from './BeforeEachSection';
+export { BeforeAllSection } from './BeforeAllSection';

--- a/frontend/src/components/RuleBuilder/RightSidebar/index.tsx
+++ b/frontend/src/components/RuleBuilder/RightSidebar/index.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useState, useMemo } from 'react';
-import { Typography } from '@mui/material';
+import { Typography, Button } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import EditIcon from '@mui/icons-material/Edit';
 import type { Node } from '@xyflow/react';
 import {
   SidebarContainer,
@@ -10,6 +11,7 @@ import {
 } from './styles';
 import { getNodeTemplate } from '../../../utils/Flow/nodeTemplateService';
 import { usesDynamicParameters } from '../../../utils/Flow/functionParameterUtils';
+import { transformRuleRequestToCode } from '../../../utils/Flow/transformRuleRequest';
 import {
   NodeHeader,
   BasicPropertiesSection,
@@ -20,6 +22,8 @@ import {
   ParameterConfigSection,
   FetchDBSection,
 } from './components';
+import { CodeEditorDialog } from './components/CodeEditorDialog';
+import { BeforeEachSection, BeforeAllSection } from './components/NodeSections';
 import { useNodeValidation, useTernaryConditions } from '../../../hooks/RuleBuilder';
 
 interface RightSidebarProps {
@@ -62,6 +66,12 @@ const RightSidebar: React.FC<RightSidebarProps> = ({
 
   const [editingLabel, setEditingLabel] = useState<string | null>(null);
   const [editingParams, setEditingParams] = useState<Record<string, string> | null>(null);
+  const [mockRequestModalOpen, setMockRequestModalOpen] = useState<boolean>(false);
+  const [mockRequestCode, setMockRequestCode] = useState<string>('');
+  const [beforeEachModalOpen, setBeforeEachModalOpen] = useState<boolean>(false);
+  const [beforeEachCode, setBeforeEachCode] = useState<string>('');
+  const [beforeAllModalOpen, setBeforeAllModalOpen] = useState<boolean>(false);
+  const [beforeAllCode, setBeforeAllCode] = useState<string>('');
   const inputRefs = React.useRef<Record<string, HTMLInputElement | HTMLTextAreaElement>>({});
   const updateTimeoutRef = React.useRef<number | null>(null);
   const validationTimeoutRef = React.useRef<number | null>(null);
@@ -441,6 +451,69 @@ const RightSidebar: React.FC<RightSidebarProps> = ({
     handleResultVarChange: handleTernaryResultVarChange,
   } = useTernaryConditions({ currentParams, onParamChange: handleTernaryParamChange });
 
+  const handleEditMockRequest = useCallback(() => {
+    if (!window.globalVariablesData) {
+      alert('No global variables data available. Please load the test case first.');
+      return;
+    }
+    
+    const globalVars = window.globalVariablesData as { RuleRequest?: unknown };
+    const transformedCode = transformRuleRequestToCode(globalVars.RuleRequest);
+    setMockRequestCode(transformedCode);
+    setMockRequestModalOpen(true);
+  }, []);
+
+  const handleSaveMockRequest = useCallback(() => {
+    if (selectedNode) {
+      const updatedParams = { ...currentParamsRef.current, ruleRequestData: mockRequestCode };
+      setEditingParams(updatedParams);
+      onUpdateNode(selectedNode.id, { params: updatedParams });
+      setMockRequestModalOpen(false);
+    }
+  }, [selectedNode, mockRequestCode, onUpdateNode]);
+
+  const handleCloseMockRequestModal = useCallback(() => {
+    setMockRequestModalOpen(false);
+  }, []);
+
+  const handleEditBeforeEach = useCallback(() => {
+    const existingCode = currentParamsRef.current.beforeEachCode || '// Add setup code here\ndatabaseManager = MockDatabaseManagerFactory();\nloggerService = MockLoggerServiceFactory();';
+    setBeforeEachCode(existingCode);
+    setBeforeEachModalOpen(true);
+  }, []);
+
+  const handleSaveBeforeEach = useCallback(() => {
+    if (selectedNode) {
+      const updatedParams = { ...currentParamsRef.current, beforeEachCode };
+      setEditingParams(updatedParams);
+      onUpdateNode(selectedNode.id, { params: updatedParams });
+      setBeforeEachModalOpen(false);
+    }
+  }, [selectedNode, beforeEachCode, onUpdateNode]);
+
+  const handleCloseBeforeEachModal = useCallback(() => {
+    setBeforeEachModalOpen(false);
+  }, []);
+
+  const handleEditBeforeAll = useCallback(() => {
+    const existingCode = currentParamsRef.current.beforeAllCode || '// Add global setup code here';
+    setBeforeAllCode(existingCode);
+    setBeforeAllModalOpen(true);
+  }, []);
+
+  const handleSaveBeforeAll = useCallback(() => {
+    if (selectedNode) {
+      const updatedParams = { ...currentParamsRef.current, beforeAllCode };
+      setEditingParams(updatedParams);
+      onUpdateNode(selectedNode.id, { params: updatedParams });
+      setBeforeAllModalOpen(false);
+    }
+  }, [selectedNode, beforeAllCode, onUpdateNode]);
+
+  const handleCloseBeforeAllModal = useCallback(() => {
+    setBeforeAllModalOpen(false);
+  }, []);
+
   if (collapsed) {
     return (
       <SidebarContainer collapsed={true}>
@@ -558,6 +631,219 @@ const RightSidebar: React.FC<RightSidebarProps> = ({
           allNodes={allNodes}
           getFieldError={getFieldError}
         />
+      ) : nodeData?.nodeType === 'RuleConfigFactory' ? (
+        <ParameterSection
+          inputs={[
+            {
+              key: 'factoryName',
+              label: 'Factory Name',
+              type: 'text',
+              required: true,
+              defaultValue: 'getRuleConfig',
+            }
+          ]}
+          currentParams={currentParams}
+          onParamChange={handleParamChange}
+          onParamBlur={handleParamBlur}
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          inputRefs={inputRefs}
+          variableError={null}
+          isReadOnly={isReadOnly}
+          viewOnly={viewOnly}
+          nodeType={nodeData?.nodeType}
+          allNodes={allNodes}
+          getFieldError={getFieldError}
+          ruleId={ruleId}
+          edges={edges}
+          selectedNodeId={selectedNode?.id}
+        />
+      ) : nodeData?.nodeType === 'RuleRequestFactory' ? (
+        <>
+          <ParameterSection
+            inputs={[
+              {
+                key: 'factoryName',
+                label: 'Factory Name',
+                type: 'text',
+                required: true,
+                defaultValue: 'getMockRequest',
+              }
+            ]}
+            currentParams={currentParams}
+            onParamChange={handleParamChange}
+            onParamBlur={handleParamBlur}
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
+            inputRefs={inputRefs}
+            variableError={null}
+            isReadOnly={isReadOnly}
+            viewOnly={viewOnly}
+            nodeType={nodeData?.nodeType}
+            allNodes={allNodes}
+            getFieldError={getFieldError}
+            ruleId={ruleId}
+            edges={edges}
+            selectedNodeId={selectedNode?.id}
+          />
+          <Button
+            variant="outlined"
+            startIcon={<EditIcon />}
+            onClick={handleEditMockRequest}
+            fullWidth
+            sx={{ mt: 2 }}
+            disabled={viewOnly}
+          >
+            Edit Mock Rule Request
+          </Button>
+        </>
+      ) : nodeData?.nodeType === 'BeforeEach' ? (
+        <BeforeEachSection onEdit={handleEditBeforeEach} viewOnly={viewOnly} />
+      ) : nodeData?.nodeType === 'BeforeAll' ? (
+        <BeforeAllSection onEdit={handleEditBeforeAll} viewOnly={viewOnly} />
+      ) : nodeData?.nodeType === 'RuleRequestScenario' ? (
+        <ParameterSection
+          inputs={[
+            {
+              key: 'factoryName',
+              label: 'Factory Name',
+              type: 'text',
+              required: true,
+              defaultValue: 'getMockRequestUnsuccessful',
+            },
+            {
+              key: 'modifications',
+              label: 'Modification Statement',
+              type: 'textarea',
+              required: false,
+              defaultValue: "quote.transaction.FIToFIPmtSts.TxInfAndSts.TxSts = 'RJCT';",
+              placeholder: "Enter modification code (e.g., quote.transaction.status = 'REJECTED';)"
+            }
+          ]}
+          currentParams={currentParams}
+          onParamChange={handleParamChange}
+          onParamBlur={handleParamBlur}
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          inputRefs={inputRefs}
+          variableError={null}
+          isReadOnly={isReadOnly}
+          viewOnly={viewOnly}
+          nodeType={nodeData?.nodeType}
+          allNodes={allNodes}
+          getFieldError={getFieldError}
+          ruleId={ruleId}
+          edges={edges}
+          selectedNodeId={selectedNode?.id}
+        />
+      ) : nodeData?.nodeType === 'RuleResultFactory' ? (
+        <ParameterSection
+          inputs={[
+            {
+              key: 'factoryName',
+              label: 'Factory Name',
+              type: 'text',
+              required: true,
+              defaultValue: 'getRuleResult',
+            }
+          ]}
+          currentParams={currentParams}
+          onParamChange={handleParamChange}
+          onParamBlur={handleParamBlur}
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          inputRefs={inputRefs}
+          variableError={null}
+          isReadOnly={isReadOnly}
+          viewOnly={viewOnly}
+          nodeType={nodeData?.nodeType}
+          allNodes={allNodes}
+          getFieldError={getFieldError}
+          ruleId={ruleId}
+          edges={edges}
+          selectedNodeId={selectedNode?.id}
+        />
+      ) : nodeData?.nodeType === 'DataCacheFactory' ? (
+        <ParameterSection
+          inputs={[
+            {
+              key: 'variableName',
+              label: 'Variable Name',
+              type: 'text',
+              required: true,
+              defaultValue: 'dataCache',
+            }
+          ]}
+          currentParams={currentParams}
+          onParamChange={handleParamChange}
+          onParamBlur={handleParamBlur}
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          inputRefs={inputRefs}
+          variableError={null}
+          isReadOnly={isReadOnly}
+          viewOnly={viewOnly}
+          nodeType={nodeData?.nodeType}
+          allNodes={allNodes}
+          getFieldError={getFieldError}
+          ruleId={ruleId}
+          edges={edges}
+          selectedNodeId={selectedNode?.id}
+        />
+      ) : nodeData?.nodeType === 'DatabaseManager' ? (
+        <ParameterSection
+          inputs={[
+            {
+              key: 'variableName',
+              label: 'Variable Name',
+              type: 'text',
+              required: true,
+              defaultValue: 'databaseManager',
+            }
+          ]}
+          currentParams={currentParams}
+          onParamChange={handleParamChange}
+          onParamBlur={handleParamBlur}
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          inputRefs={inputRefs}
+          variableError={null}
+          isReadOnly={isReadOnly}
+          viewOnly={viewOnly}
+          nodeType={nodeData?.nodeType}
+          allNodes={allNodes}
+          getFieldError={getFieldError}
+          ruleId={ruleId}
+          edges={edges}
+          selectedNodeId={selectedNode?.id}
+        />
+      ) : nodeData?.nodeType === 'LoggerService' ? (
+        <ParameterSection
+          inputs={[
+            {
+              key: 'variableName',
+              label: 'Variable Name',
+              type: 'text',
+              required: true,
+              defaultValue: 'loggerService',
+            }
+          ]}
+          currentParams={currentParams}
+          onParamChange={handleParamChange}
+          onParamBlur={handleParamBlur}
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          inputRefs={inputRefs}
+          variableError={null}
+          isReadOnly={isReadOnly}
+          viewOnly={viewOnly}
+          nodeType={nodeData?.nodeType}
+          allNodes={allNodes}
+          getFieldError={getFieldError}
+          ruleId={ruleId}
+          edges={edges}
+          selectedNodeId={selectedNode?.id}
+        />
       ) : isFunctionCallNode && (nodeData?.function_name || template?.function_name) ? (
         <FunctionCallSection
           functionName={nodeData?.function_name || template.function_name || ''}
@@ -599,6 +885,33 @@ const RightSidebar: React.FC<RightSidebarProps> = ({
           />
         )
       )}
+
+      <CodeEditorDialog
+        open={mockRequestModalOpen}
+        title="Edit Mock Rule Request"
+        value={mockRequestCode}
+        onChange={setMockRequestCode}
+        onSave={handleSaveMockRequest}
+        onClose={handleCloseMockRequestModal}
+      />
+
+      <CodeEditorDialog
+        open={beforeEachModalOpen}
+        title="Edit beforeEach Code"
+        value={beforeEachCode}
+        onChange={setBeforeEachCode}
+        onSave={handleSaveBeforeEach}
+        onClose={handleCloseBeforeEachModal}
+      />
+
+      <CodeEditorDialog
+        open={beforeAllModalOpen}
+        title="Edit beforeAll Code"
+        value={beforeAllCode}
+        onChange={setBeforeAllCode}
+        onSave={handleSaveBeforeAll}
+        onClose={handleCloseBeforeAllModal}
+      />
     </SidebarContainer>
   );
 };

--- a/frontend/src/hooks/RuleBuilder/EditableNode/useNodeHandles.ts
+++ b/frontend/src/hooks/RuleBuilder/EditableNode/useNodeHandles.ts
@@ -96,6 +96,31 @@ export const useNodeHandles = (
           border: '2px solid white',
         },
       });
+    } else if (hasSourceHandle && nodeType === 'Describe') {
+      result.sourceHandles.push({
+        id: 'body',
+        type: 'source',
+        position: Position.Right,
+        style: {
+          background: '#9c27b0',
+          width: '10px',
+          height: '10px',
+          border: '2px solid white',
+          top: '50%',
+        },
+      });
+
+      result.sourceHandles.push({
+        id: 'exit',
+        type: 'source',
+        position: Position.Bottom,
+        style: {
+          background: '#000000',
+          width: '10px',
+          height: '10px',
+          border: '2px solid white',
+        },
+      });
     } else if (hasSourceHandle) {
       result.sourceHandles.push({
         id: 'source',

--- a/frontend/src/hooks/RuleBuilder/useCanvasCodeGeneration.ts
+++ b/frontend/src/hooks/RuleBuilder/useCanvasCodeGeneration.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from 'react';
 import type { Node, Edge } from '@xyflow/react';
 import { sortNodesInFlowOrder } from '../../utils/Common/helpers';
-import { generateTypeScriptCode } from '../../utils/Flow/CodeGenerator';
+import { generateTypeScriptCode, generateTestCaseCode } from '../../utils/Flow/CodeGenerator';
 
 interface NestedCanvasData {
   nodes: Node[];
@@ -15,6 +15,7 @@ interface UseCanvasCodeGenerationProps {
   onJsonGenerate?: (json: string) => void;
   onCodeGenerate?: (code: string) => void;
   reactFlowInstance?: Record<string, unknown>;
+  mode?: 'rule-builder' | 'test-case-generate';
 }
 
 export const useCanvasCodeGeneration = ({
@@ -23,6 +24,7 @@ export const useCanvasCodeGeneration = ({
   nestedCanvasData,
   onJsonGenerate,
   onCodeGenerate,
+  mode = 'rule-builder'
 }: UseCanvasCodeGenerationProps) => {
   const generateJson = useCallback(() => {
     const flowData = {
@@ -110,15 +112,18 @@ export const useCanvasCodeGeneration = ({
     }
     return json;
   }, [nodes, edges, nestedCanvasData, onJsonGenerate]);
+  
   const generateCode = useCallback(() => {
-    const code = generateTypeScriptCode(nodes, edges, nestedCanvasData);
+    const code = mode === 'test-case-generate' 
+      ? generateTestCaseCode(nodes, edges)
+      : generateTypeScriptCode(nodes, edges, nestedCanvasData);
 
     if (onCodeGenerate) {
       onCodeGenerate(code);
     }
     
     return code;
-  }, [nodes, edges, nestedCanvasData, onCodeGenerate]);
+  }, [nodes, edges, nestedCanvasData, onCodeGenerate, mode]);
 
   useEffect(() => {
     window.generateFlowJson = generateJson;

--- a/frontend/src/hooks/RuleBuilder/useCanvasNodeOperations.ts
+++ b/frontend/src/hooks/RuleBuilder/useCanvasNodeOperations.ts
@@ -30,6 +30,59 @@ export const useCanvasNodeOperations = ({
         });
       }
 
+      if (type === 'RuleConfigFactory' && window.globalVariablesData) {
+        try {
+          const globalVars = window.globalVariablesData as { RuleConfig?: unknown };
+          if (globalVars.RuleConfig) {
+            defaultParams.ruleConfigData = JSON.stringify(globalVars.RuleConfig);
+          }
+        } catch (error) {
+          console.error('Error auto-populating RuleConfig data:', error);
+        }
+      }
+
+      if (type === 'RuleRequestFactory' && window.globalVariablesData) {
+        try {
+          const globalVars = window.globalVariablesData as { RuleRequest?: unknown };
+          if (globalVars.RuleRequest) {
+            // Import the transform function dynamically
+            import('../../utils/Flow/transformRuleRequest').then(({ transformRuleRequestToCode }) => {
+              const transformedCode = transformRuleRequestToCode(globalVars.RuleRequest);
+              // Update the node params after creation
+              setNodes((nds) =>
+                nds.map((node) =>
+                  node.id === newNodeId
+                    ? { 
+                        ...node, 
+                        data: { 
+                          ...node.data, 
+                          params: { 
+                            ...((node.data as EditableNodeData).params as Record<string, string> || {}), 
+                            ruleRequestData: transformedCode 
+                          } 
+                        } 
+                      }
+                    : node
+                )
+              );
+            });
+          }
+        } catch (error) {
+          console.error('Error auto-populating RuleRequest data:', error);
+        }
+      }
+
+      if (type === 'RuleResultFactory' && window.globalVariablesData) {
+        try {
+          const globalVars = window.globalVariablesData as { RuleResult?: unknown };
+          if (globalVars.RuleResult) {
+            defaultParams.ruleResultData = JSON.stringify(globalVars.RuleResult);
+          }
+        } catch (error) {
+          console.error('Error auto-populating RuleResult data:', error);
+        }
+      }
+
       const newNode: Node = {
         id: newNodeId,
         type: 'editableNode',

--- a/frontend/src/hooks/RuleBuilder/useNodePalette.ts
+++ b/frontend/src/hooks/RuleBuilder/useNodePalette.ts
@@ -36,6 +36,7 @@ interface UseNodePaletteProps {
   mode?: 'main' | 'modal';
   hideCustomFunctions?: boolean;
   hideImportNode?: boolean;
+  hideStartEnd?: boolean;
   apiNodes?: NodeTemplate[];
 }
 
@@ -43,37 +44,31 @@ export const useNodePalette = ({
   mode = 'main', 
   hideCustomFunctions = false,
   hideImportNode = false,
+  hideStartEnd = false,
   apiNodes = [],
 }: UseNodePaletteProps) => {
   const basicNodes: NodeTemplate[] = useMemo(
     () => {
-      if (apiNodes && apiNodes.length > 0) {
-        let nodes = apiNodes.filter((node) => {
-          const visibleOn = node.visible_on_canvas || ['main', 'nested'];
-          const isVisibleOnThisCanvas = mode === 'modal' 
-            ? visibleOn.includes('nested') 
-            : visibleOn.includes('main');
-          
-          return !node.isFunction && isVisibleOnThisCanvas;
-        });
+      let nodes = apiNodes.filter((node) => {
+        const visibleOn = node.visible_on_canvas || ['main', 'nested'];
+        const isVisibleOnThisCanvas = mode === 'modal' 
+          ? visibleOn.includes('nested') 
+          : visibleOn.includes('main');
         
-        if (hideImportNode) {
-          nodes = nodes.filter((node) => node.type !== 'Import');
-        }
-        return nodes;
+        return !node.isFunction && isVisibleOnThisCanvas;
+      });
+      
+      if (hideImportNode) {
+        nodes = nodes.filter((node) => node.type !== 'Import');
       }
-      const nodes = [
-        { type: 'Import', label: 'Import', description: 'Import modules', color: '#8b5cf6' },
-        { type: 'SetVariable', label: 'Set Variable', description: 'Assign value to variable', color: '#60a5fa' },
-        { type: 'Log', label: 'Print Log', description: 'Output to console', color: '#fbbf24' },
-        { type: 'If', label: 'If Condition', description: 'Conditional branch', color: '#ec4899' },
-        { type: 'Code', label: 'Custom Code', description: 'Execute custom code', color: '#a78bfa' },
-        { type: 'FetchDB', label: 'Fetch from DB', description: 'Database query', color: '#fb923c' },
-        { type: 'ThrowError', label: 'Throw Error', description: 'Raise an error', color: '#f87171' },
-      ];
-      return hideImportNode ? nodes.filter((n) => n.type !== 'Import') : nodes;
+      
+      if (hideStartEnd) {
+        nodes = nodes.filter((node) => node.type !== 'Start' && node.type !== 'End');
+      }
+      
+      return nodes;
     },
-    [apiNodes, hideImportNode, mode]
+    [apiNodes, hideImportNode, hideStartEnd, mode]
   );
 
   const modalNodes: NodeTemplate[] = useMemo(
@@ -83,17 +78,14 @@ export const useNodePalette = ({
 
   const functionNodes: NodeTemplate[] = useMemo(
     () => {
-      if (apiNodes && apiNodes.length > 0) {
-        return apiNodes.filter((node) => {
-          if (!node.isFunction) return false;
-          
-          const visibleOn = node.visible_on_canvas || ['nested'];
-          return mode === 'modal' 
-            ? visibleOn.includes('nested') 
-            : visibleOn.includes('main');
-        });
-      }
-      return [];
+      return apiNodes.filter((node) => {
+        if (!node.isFunction) return false;
+        
+        const visibleOn = node.visible_on_canvas || ['nested'];
+        return mode === 'modal' 
+          ? visibleOn.includes('nested') 
+          : visibleOn.includes('main');
+      });
     },
     [apiNodes, mode]
   );

--- a/frontend/src/pages/test-case-generate/index.tsx
+++ b/frontend/src/pages/test-case-generate/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useEffect, useRef, useCallback, useState, useMemo } from 'react';
 import { Box, Typography } from '@mui/material';
 import { useParams } from 'react-router-dom';
 import toast from 'react-hot-toast';
@@ -7,75 +7,57 @@ import LeftSidebar from '../../components/RuleBuilder/LeftSidebar';
 import Header from '../../components/RuleBuilder/Header';
 import RuleBuilderCanvas from '../../components/RuleBuilder/Canvas';
 import RightSidebar from '../../components/RuleBuilder/RightSidebar';
-import NestedCanvas from '../../components/RuleBuilder/NestedCanvas';
 import OutputModal from '../../components/RuleBuilder/OutputModal';
 import { ValidationProvider } from '../../validation/context';
 import { ValidationErrorModal } from '../../components/RuleBuilder/ValidationErrorModal';
-import { useGetFlowQuery, useSaveFlowMutation, useGetNodesQuery } from '../../redux/Api/Rule-builder';
-import { transformApiFlowData, type ApiNode, type ApiEdge } from '../../utils/Flow/FlowTransformers';
+import { useGetNodesQuery, useSaveFlowMutation, useGetGlobalVariablesQuery, useGetFlowQuery } from '../../redux/Api/Rule-builder';
 import { setApiNodes } from '../../utils/Flow/nodeTemplateService';
-import {
-  useFlowAnimation,
-  useFlowState,
-  useNestedCanvasManager,
-} from '../../hooks/RuleBuilder';
+import { transformApiFlowData, type ApiNode as ApiFlowNode, type ApiEdge } from '../../utils/Flow/FlowTransformers';
+import { useFlowState } from '../../hooks/RuleBuilder';
 
-interface RuleBuilderProps {
+interface TestCaseGenerateProps {
   viewOnly?: boolean;
 }
 
-const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
-  const { id: ruleId } = useParams<{ id: string }>();
+const TestCaseGenerate: React.FC<TestCaseGenerateProps> = ({ viewOnly = false }) => {
+  const { ruleId } = useParams<{ ruleId: string }>();
   
-  const { data: nodesData, isLoading: isLoadingNodes, error: nodesError } = useGetNodesQuery('rule_builder');
-  
-  const { data: flowData, isLoading: isLoadingFlow, error: flowError } = useGetFlowQuery(
-    { ruleId: ruleId || '', category: 'rule_builder' },
+  const { data: nodesData, isLoading: isLoadingNodes, error: nodesError } = useGetNodesQuery('test_case_generation');
+  const { data: globalVariablesData } = useGetGlobalVariablesQuery(ruleId || '', {
+    skip: !ruleId,
+  });
+  const { data: flowData } = useGetFlowQuery(
+    { ruleId: ruleId || '', category: 'test_case_generation' },
     { skip: !ruleId }
   );
-  
   const [saveFlow, { isLoading: isSaving }] = useSaveFlowMutation();
   
   const flowState = useFlowState();
-  const nestedCanvasManager = useNestedCanvasManager();
   
-  // Store reference to updateNodeInternals from Canvas for dynamic handle updates
-  const updateNodeInternalsRef = React.useRef<((nodeId: string) => void) | null>(null);
-  
-  const [apiNodesInitialized, setApiNodesInitialized] = React.useState(false);
-  
-  useEffect(() => {
-    if (nodesData && Array.isArray(nodesData)) {
-      setApiNodes(nodesData as unknown as ApiNode[]);
-      setApiNodesInitialized(true);
-    }
+  const updateNodeInternalsRef = useRef<((nodeId: string) => void) | null>(null);
+  // Initialize API nodes synchronously using useMemo
+  const apiNodesInitialized = useMemo(() => {
+    if (!nodesData || !Array.isArray(nodesData)) return false;
+    setApiNodes(nodesData);
+    return true;
   }, [nodesData]);
-  
-  const transformedFlowData = useMemo(() => {
 
+  const transformedFlowData = useMemo(() => {
     if (!flowData?.flow || !apiNodesInitialized) return null;
     
     const flowJson = flowData.flow.flow_json || flowData.flow;
     
     return transformApiFlowData(
-      flowJson.nodes as ApiNode[] || [],
+      flowJson.nodes as ApiFlowNode[] || [],
       flowJson.edges as ApiEdge[] || []
     );
   }, [flowData, apiNodesInitialized]);
 
   useEffect(() => {
-    if (transformedFlowData?.nestedFlows) {
-      Object.entries(transformedFlowData.nestedFlows).forEach(([nodeId, nestedFlow]) => {
-        nestedCanvasManager.setNestedCanvasData(prev => ({
-          ...prev,
-          [nodeId]: nestedFlow,
-        }));
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [transformedFlowData]);
+    window.globalVariablesData = globalVariablesData || null;
+  }, [globalVariablesData]);
 
-  const [showErrorModal, setShowErrorModal] = React.useState(false);
+  const [showErrorModal, setShowErrorModal] = useState<boolean>(false);
 
   useEffect(() => {
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
@@ -90,63 +72,18 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
   }, []);
-  
-  const [isPaused, setIsPaused] = React.useState(false);
-  
-  const {
-    playFlowAnimation,
-    stopAnimation,
-    pauseAnimation,
-    resumeAnimation,
-    updateFlowState,
-    animationTimeoutRef,
-  } = useFlowAnimation({
-    isPlaying: Boolean(flowState.currentAnimationNode),
-    setIsPlaying: () => {},
-    nestedCanvasData: nestedCanvasManager.nestedCanvasData,
-    setDebugVariables: flowState.setDebugVariables,
-    setDebugLogs: flowState.setDebugLogs,
-    setCurrentAnimationNode: flowState.setCurrentAnimationNode,
-  });
 
   const nodeUpdateHandlerRef = useRef<((nodeId: string, updates: Record<string, unknown>) => void) | null>(null);
 
-  const handlePlayClick = () => {
-    if (nestedCanvasManager.activeNestedCanvas) {
-      nestedCanvasManager.setActiveNestedCanvas(null);
-      flowState.setSelectedNode(null);
-      setTimeout(playFlowAnimation, 100);
-    } else {
-      playFlowAnimation();
-    }
-  };
-
-  const handlePauseClick = () => {
-    setIsPaused(true);
-    pauseAnimation();
-  };
-
-  const handleResumeClick = () => {
-    setIsPaused(false);
-    resumeAnimation();
-  };
-
-  const handleStopClick = () => {
-    setIsPaused(false);
-    stopAnimation();
-    flowState.setDebugLogs([]);
-    flowState.setDebugVariables({});
-  };
-
-  const handleDisplayJson = () => {
+  const handleDisplayJson = useCallback(() => {
     window.generateFlowJson?.();
-  };
+  }, []);
 
-  const handleGenerateCode = () => {
+  const handleGenerateCode = useCallback(() => {
     window.generateFlowCode?.();
-  };
+  }, []);
 
-  const handleSave = async () => {
+  const handleSave = useCallback(async () => {
     if (!ruleId) {
       toast.error('Rule ID not found');
       return;
@@ -168,9 +105,8 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
       let parsedFlowJson;
       try {
         parsedFlowJson = JSON.parse(flowJson);
-      } catch (parseError) {
+      } catch {
         toast.error('Failed to parse flow data: Invalid JSON format');
-        console.error('JSON parse error:', parseError);
         return;
       }
 
@@ -184,30 +120,28 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
       const response = await saveFlow({
         ruleId,
         flowData: payload,
-        category: 'rule_builder',
+        category: 'test_case_generation',
       }).unwrap();
 
-      toast.success(response.message || 'Flow saved successfully');
+      toast.success(response.message || 'Test case flow saved successfully');
     } catch (error: unknown) {
-      const errorMessage = (error as { data?: { message?: string } })?.data?.message || 'Failed to save flow';
+      const errorMessage = (error as { data?: { message?: string } })?.data?.message || 'Failed to save test case';
       toast.error(errorMessage);
     }
-  };
+  }, [ruleId, saveFlow]);
+
+  const flowStateRef = useRef(flowState);
+  
+  useEffect(() => {
+    flowStateRef.current = flowState;
+  }, [flowState]);
 
   const handleNodeSelect = useCallback((node: Node | null) => {
     if (node?.data.nodeType === 'Start' || node?.data.nodeType === 'End') {
-      flowState.setSelectedNode(null);
       return;
     }
-    
-    if (node?.data.nodeType === 'HandleTransaction') {
-      nestedCanvasManager.openNestedCanvas(node.id, String(node.data.label || 'Handle Transaction'));
-      flowState.setSelectedNode(null);
-    } else {
-      flowState.setSelectedNode(node);
-      nestedCanvasManager.setActiveNestedCanvas(null);
-    }
-  }, [nestedCanvasManager, flowState]);
+    flowStateRef.current.setSelectedNode(node);
+  }, []);
 
   const handleNodeUpdateHandlerReady = useCallback((handler: (nodeId: string, updates: Record<string, unknown>) => void) => {
     nodeUpdateHandlerRef.current = handler;
@@ -225,41 +159,20 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
     updateNodeInternalsRef.current?.(nodeId);
   }, []);
 
-  const handleFlowStateUpdate = ((
+  const handleFlowStateUpdate = useCallback((
     nodes: Node[], 
-    edges: Edge[], 
-    setNodes: (nodes: Node[] | ((prevNodes: Node[]) => Node[])) => void, 
-    setEdges: (edges: Edge[] | ((prevEdges: Edge[]) => Edge[])) => void
+    edges: Edge[]
   ) => {
-    updateFlowState(nodes, edges, setNodes, setEdges);
-    flowState.setAllNodes(nodes);
-    flowState.setEdges(edges);
-  });
-  
-  const handleNestedCanvasSave = ((nodes: Node[], edges: Edge[]) => {
-    if (nestedCanvasManager.activeNestedCanvas) {
-      nestedCanvasManager.handleNestedCanvasSave(nestedCanvasManager.activeNestedCanvas, nodes, edges);
-    }
-  });
-
-  useEffect(() => {
-    const timeoutRef = animationTimeoutRef.current;
-    return () => {
-      if (timeoutRef) {
-        clearTimeout(timeoutRef);
-      }
-    };
-  }, [animationTimeoutRef]);
+    flowStateRef.current.setAllNodes(nodes);
+    flowStateRef.current.setEdges(edges);
+  }, []);
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden' }}>
       <Header
-        isPlaying={Boolean(flowState.currentAnimationNode)}
-        isPaused={isPaused}
-        onPlayClick={handlePlayClick}
-        onPauseClick={handlePauseClick}
-        onResumeClick={handleResumeClick}
-        onStopClick={handleStopClick}
+        hidePlayControls={true}
+        onPlayClick={() => {}}
+        onStopClick={() => {}}
         onDisplayJson={handleDisplayJson}
         onGenerateCode={handleGenerateCode}
         onViewErrors={() => setShowErrorModal(true)}
@@ -267,24 +180,21 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
         isSaving={isSaving}
         viewOnly={viewOnly}
       />
-      {nodesError || flowError ? (
+      {nodesError ? (
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', flex: 1, flexDirection: 'column', gap: 2 }}>
           <Typography variant="h6" color="error">
-            Error loading rule builder
+            Error loading test case builder
           </Typography>
           <Typography variant="body2">
-            {nodesError ? 'Failed to load node templates' : 'Failed to load rule flow'}
+            Failed to load node templates
           </Typography>
         </Box>
-      ) : isLoadingNodes || isLoadingFlow || !apiNodesInitialized ? (
+      ) : isLoadingNodes || !apiNodesInitialized ? (
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', flex: 1, flexDirection: 'column', gap: 2 }}>
-          <Typography variant="h6">
-            {isLoadingNodes ? 'Loading node templates...' : isLoadingFlow ? 'Loading rule flow...' : 'Initializing...'}
-          </Typography>
-          <Typography variant="body2" color="textSecondary">
+          <Typography>Loading...</Typography>
+          <Typography variant="body2" color="text.secondary">
             {isLoadingNodes && 'Fetching available nodes from server'}
-            {isLoadingFlow && !isLoadingNodes && 'Fetching rule configuration'}
-            {!isLoadingNodes && !isLoadingFlow && !apiNodesInitialized && 'Setting up canvas...'}
+            {!isLoadingNodes && !apiNodesInitialized && 'Setting up canvas...'}
           </Typography>
         </Box>
       ) : !transformedFlowData ? (
@@ -298,7 +208,8 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
               mode="main" 
               collapsed={flowState.sidebarCollapsed}
               onToggleCollapse={flowState.handleToggleSidebar}
-              hideCustomFunctions={nestedCanvasManager.activeNestedCanvas !== null}
+              hideCustomFunctions={false}
+              hideStartEnd={true}
               allNodes={flowState.allNodes}
               edges={flowState.edges}
               selectedNodeId={flowState.selectedNode?.id || null}
@@ -306,20 +217,17 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
             />
           )}
           <RuleBuilderCanvas
-            isPlaying={Boolean(flowState.currentAnimationNode)}
             onJsonGenerate={flowState.handleJsonGenerate}
             onCodeGenerate={flowState.handleCodeGenerate}
             onNodeSelect={handleNodeSelect}
             onNodeUpdateHandlerReady={handleNodeUpdateHandlerReady}
-            debugVariables={flowState.debugVariables}
-            debugLogs={flowState.debugLogs}
-            currentNodeId={flowState.currentAnimationNode}
-            nestedCanvasData={nestedCanvasManager.nestedCanvasData}
+            nestedCanvasData={{}}
             viewOnly={viewOnly}
             onFlowStateUpdate={handleFlowStateUpdate}
             initialNodes={transformedFlowData?.nodes}
             initialEdges={transformedFlowData?.edges}
             onUpdateNodeInternalsReady={handleUpdateNodeInternalsReady}
+            mode="test-case-generate"
           />
           <RightSidebar
             key={flowState.selectedNode?.id || 'no-selection'}
@@ -332,20 +240,6 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
             edges={flowState.edges}
             updateNodeInternals={handleUpdateNodeInternals}
           />
-
-          {nestedCanvasManager.activeNestedCanvas && (
-            <NestedCanvas
-              nodeId={nestedCanvasManager.activeNestedCanvas}
-              nodeLabel={nestedCanvasManager.activeNestedCanvasLabel}
-              initialNodes={nestedCanvasManager.nestedCanvasData[nestedCanvasManager.activeNestedCanvas]?.nodes}
-              initialEdges={nestedCanvasManager.nestedCanvasData[nestedCanvasManager.activeNestedCanvas]?.edges}
-              onBack={nestedCanvasManager.handleNestedCanvasBack}
-              onSave={handleNestedCanvasSave}
-              viewOnly={viewOnly}
-              ruleId={ruleId}
-              mainCanvasNodes={flowState.allNodes}
-            />
-          )}
         </Box>
       )}
 
@@ -376,12 +270,12 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
   );
 };
 
-const RuleBuilderWithValidation: React.FC<RuleBuilderProps> = (props) => {
+const TestCaseGenerateWithValidation: React.FC<TestCaseGenerateProps> = (props) => {
   return (
     <ValidationProvider>
-      <RuleBuilder {...props} />
+      <TestCaseGenerate {...props} />
     </ValidationProvider>
   );
 };
 
-export default RuleBuilderWithValidation;
+export default TestCaseGenerateWithValidation;

--- a/frontend/src/redux/Api/Rule-builder/index.ts
+++ b/frontend/src/redux/Api/Rule-builder/index.ts
@@ -16,22 +16,22 @@ export const ruleBuilderApi = createApi({
     }),
     endpoints: (builder) => ({
         getNodes: builder.query({
-            query: () => ({
-                url: `nodes?category=rule_builder`,
+            query: (category: string = 'rule_builder') => ({
+                url: `nodes?category=${category}`,
                 method: "GET",
             }),
         }),
         getFlow: builder.query({
-            query: (ruleId: string | number) => ({
-                url: `rules/api/${ruleId}/flow`,
+            query: ({ ruleId, category = 'rule_builder' }: { ruleId: string | number; category?: string }) => ({
+                url: `rules/api/${ruleId}/flow?category=${category}`,
                 method: "GET",
             }),
         }),
         saveFlow: builder.mutation({
-            query: ({ ruleId, flowData }: { ruleId: string | number; flowData: unknown }) => ({
+            query: ({ ruleId, flowData, category = 'rule_builder' }: { ruleId: string | number; flowData: unknown; category?: string }) => ({
                 url: `rules/api/${ruleId}/flow`,
                 method: "PUT",
-                body: flowData,
+                body: { ...(flowData as Record<string, unknown>), category },
             }),
         }),
         getGlobalVariables: builder.query({

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { lazy } from "react";
 import { Navigate } from "react-router-dom";
 import RuleBuilder from "../pages/rule-builder";
+import TestCaseGenerate from "../pages/test-case-generate";
 
 const Components = lazy(() => import("../components"));
 const Login = lazy(() => import("../pages/Auth/Login"));
@@ -54,6 +55,18 @@ export const ROUTES = [
     {
         path: '/rule-builder/view/:id',
         element: <RuleBuilder viewOnly />,
+        private: true,
+        layout: false
+    },
+    {
+        path: '/test-case-generate/:ruleId',
+        element: <TestCaseGenerate />,
+        private: true,
+        layout: false
+    },
+    {
+        path: '/test-case-generate/view/:ruleId',
+        element: <TestCaseGenerate viewOnly />,
         private: true,
         layout: false
     },

--- a/frontend/src/types/window.d.ts
+++ b/frontend/src/types/window.d.ts
@@ -5,6 +5,7 @@ declare global {
     generateFlowCode?: () => string;
     generateNestedFlowJson?: () => void;
     generateNestedFlowCode?: () => void;
+    globalVariablesData?: unknown;
   }
 }
 

--- a/frontend/src/utils/Common/helpers.ts
+++ b/frontend/src/utils/Common/helpers.ts
@@ -68,16 +68,18 @@ export const getLabelForHandle = (handleId: string): string => {
   if (handleId === 'else') return 'else';
   if (handleId === 'exit') return 'exit';
   if (handleId === 'loopBody') return 'loop body';
+  if (handleId === 'body') return 'body';
   if (handleId.startsWith('elseif')) return 'else if';
   return '';
 };
 
 export const getColorForHandle = (handleId: string): string => {
-  if (handleId === 'if') return '#4caf50'; // green
-  if (handleId === 'else') return '#4caf50'; // green
-  if (handleId === 'exit') return '#000000'; // black for continuation
-  if (handleId === 'loopBody') return '#2196F3'; // blue for loop body
-  if (handleId.startsWith('elseif')) return '#4caf50'; // green
+  if (handleId === 'if') return '#4caf50';
+  if (handleId === 'else') return '#4caf50';
+  if (handleId === 'exit') return '#000000';
+  if (handleId === 'loopBody') return '#2196F3';
+  if (handleId === 'body') return '#9c27b0';
+  if (handleId.startsWith('elseif')) return '#4caf50';
   return '#555';
 };
 
@@ -105,7 +107,9 @@ export const getNodesInBranch = <T extends NodeWithId, E extends EdgeWithSourceT
     visitedNodes.add(targetNode.id);
     branchNodes.push(targetNode);
 
-    if (nodeData?.nodeType !== 'If') {
+    // Don't recursively collect nodes from block structures (If, Loop, Describe)
+    // They handle their own branching logic
+    if (nodeData?.nodeType !== 'If' && nodeData?.nodeType !== 'Loop' && nodeData?.nodeType !== 'Describe') {
       const childNodes = getNodesInBranch(targetNode.id, null, nodes, edges, visitedNodes);
       branchNodes.push(...childNodes);
     }

--- a/frontend/src/utils/Flow/CodeGenerator.ts
+++ b/frontend/src/utils/Flow/CodeGenerator.ts
@@ -97,6 +97,27 @@ const generateNodeCode = (node: Node, indent: string = '', allNodes?: Node[]): s
 
   const template = getNodeTemplate(nodeType, mode);
 
+  if (nodeType === 'Import') {
+    const importStatement = params.importStatement || '';
+    return stripVariableIndicators(importStatement).trim();
+  }
+
+  if (nodeType === 'RuleConfigFactory') {
+    return generateRuleConfigFactoryCode(params, indent);
+  }
+
+  if (nodeType === 'RuleRequestFactory') {
+    return generateRuleRequestFactoryCode(params, indent);
+  }
+
+  if (nodeType === 'RuleResultFactory') {
+    return generateRuleResultFactoryCode(params, indent);
+  }
+
+  if (nodeType === 'DataCacheFactory') {
+    return '\n' + generateDataCacheFactoryCode(params, indent);
+  }
+
   if (nodeType === 'If') {
     return generateIfNodeCode(node, indent);
   }
@@ -173,6 +194,178 @@ const generateNodeCode = (node: Node, indent: string = '', allNodes?: Node[]): s
   }
 
   return `${indent}// ${nodeType} - ${nodeData.label}`;
+};
+
+const generateRuleConfigFactoryCode = (params: Record<string, string>, indent: string): string => {
+  const factoryName = params.factoryName || 'getRuleConfig';
+  const ruleConfigData = params.ruleConfigData || '';
+  
+  if (!ruleConfigData) {
+    return `${indent}const ${factoryName} = (): RuleConfig => {\n${indent}  return {} as RuleConfig;\n${indent}};`;
+  }
+  
+  try {
+    // Parse the RuleConfig data
+    const ruleConfig = JSON.parse(ruleConfigData);
+    
+    // Format the object with proper indentation
+    const formatObject = (obj: unknown, currentIndent: string): string => {
+      if (obj === null) return 'null';
+      if (obj === undefined) return 'undefined';
+      if (typeof obj === 'string') return `'${obj.replace(/'/g, "\\'")}'`;
+      if (typeof obj === 'number' || typeof obj === 'boolean') return String(obj);
+      
+      if (Array.isArray(obj)) {
+        if (obj.length === 0) return '[]';
+        const items = obj.map(item => `${currentIndent}  ${formatObject(item, currentIndent + '  ')}`).join(',\n');
+        return `[\n${items},\n${currentIndent}]`;
+      }
+      
+      if (typeof obj === 'object') {
+        const entries = Object.entries(obj);
+        if (entries.length === 0) return '{}';
+        const props = entries.map(([key, value]) => {
+          const formattedValue = formatObject(value, currentIndent + '  ');
+          return `${currentIndent}  ${key}: ${formattedValue}`;
+        }).join(',\n');
+        return `{\n${props},\n${currentIndent}}`;
+      }
+      
+      return 'undefined';
+    };
+    
+    const formattedConfig = formatObject(ruleConfig, indent + '  ');
+    
+    return `${indent}const ${factoryName} = (): RuleConfig => {\n${indent}  return ${formattedConfig};\n${indent}};`;
+  } catch (error) {
+    console.error('Error parsing RuleConfig data:', error);
+    return `${indent}const ${factoryName} = (): RuleConfig => {\n${indent}  // Error parsing RuleConfig data\n${indent}  return {} as RuleConfig;\n${indent}};`;
+  }
+};
+
+const generateRuleRequestFactoryCode = (params: Record<string, string>, indent: string): string => {
+  const factoryName = params.factoryName || 'getMockRequest';
+  const ruleRequestData = params.ruleRequestData || '';
+  
+  if (!ruleRequestData) {
+    return `${indent}const ${factoryName} = (): RuleRequest => {\n${indent}  const quote = {\n${indent}    transaction: JSON.parse(''),\n${indent}    networkMap: JSON.parse(''),\n${indent}    DataCache: JSON.parse(''),\n${indent}  };\n${indent}  return quote;\n${indent}};`;
+  }
+  
+  // If it's already transformed code (from Monaco editor), use it directly
+  if (ruleRequestData.includes('JSON.parse') || ruleRequestData.includes('const quote')) {
+    // Remove leading/trailing whitespace but preserve internal formatting
+    const codeLines = ruleRequestData.split('\n').map(line => `${indent}${line}`).join('\n');
+    return `${indent}const ${factoryName} = (): RuleRequest => {\n${codeLines}\n${indent}};`;
+  }
+  
+  // Otherwise, treat it as JSON and transform it
+  try {
+    const ruleRequest = JSON.parse(ruleRequestData);
+    
+    // Transform into the required format with proper escaping
+    const transactionStr = ruleRequest.transaction ? JSON.stringify(ruleRequest.transaction) : '';
+    const networkMapStr = ruleRequest.networkMap ? JSON.stringify(ruleRequest.networkMap) : '';
+    const dataCacheStr = ruleRequest.DataCache ? JSON.stringify(ruleRequest.DataCache) : '';
+    
+    // Escape for template literals and single quotes
+    const escapeForTemplate = (str: string) => str.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$/g, '\\$');
+    const escapeForSingleQuote = (str: string) => str.replace(/'/g, "\\'");
+    
+    return `${indent}const ${factoryName} = (): RuleRequest => {\n${indent}  const quote = {\n${indent}    transaction: JSON.parse(\n${indent}      \`${escapeForTemplate(transactionStr)}\`,\n${indent}    ),\n${indent}    networkMap: JSON.parse(\n${indent}      '${escapeForSingleQuote(networkMapStr)}',\n${indent}    ),\n${indent}    DataCache: JSON.parse(\n${indent}      '${escapeForSingleQuote(dataCacheStr)}',\n${indent}    ),\n${indent}  };\n${indent}  return quote;\n${indent}};`;
+  } catch (error) {
+    console.error('Error parsing RuleRequest data:', error);
+    return `${indent}const ${factoryName} = (): RuleRequest => {\n${indent}  // Error parsing RuleRequest data\n${indent}  return {} as RuleRequest;\n${indent}};`;
+  }
+};
+
+const generateRuleResultFactoryCode = (params: Record<string, string>, indent: string): string => {
+  const factoryName = params.factoryName || 'getRuleResult';
+  const ruleResultData = params.ruleResultData || '';
+  
+  if (!ruleResultData) {
+    return `${indent}const ${factoryName} = (): RuleResult => {\n${indent}  return {} as RuleResult;\n${indent}};`;
+  }
+  
+  try {
+    const ruleResult = JSON.parse(ruleResultData);
+    
+    const formatObject = (obj: unknown, currentIndent: string): string => {
+      if (obj === null) return 'null';
+      if (obj === undefined) return 'undefined';
+      if (typeof obj === 'string') return `'${obj.replace(/'/g, "\\'")}'`;
+      if (typeof obj === 'number' || typeof obj === 'boolean') return String(obj);
+      
+      if (Array.isArray(obj)) {
+        if (obj.length === 0) return '[]';
+        const items = obj.map(item => `${currentIndent}  ${formatObject(item, currentIndent + '  ')}`).join(',\n');
+        return `[\n${items},\n${currentIndent}]`;
+      }
+      
+      if (typeof obj === 'object') {
+        const entries = Object.entries(obj);
+        if (entries.length === 0) return '{}';
+        const props = entries.map(([key, value]) => {
+          const formattedValue = formatObject(value, currentIndent + '  ');
+          return `${currentIndent}  ${key}: ${formattedValue}`;
+        }).join(',\n');
+        return `{\n${props},\n${currentIndent}}`;
+      }
+      
+      return 'undefined';
+    };
+    
+    const formattedResult = formatObject(ruleResult, indent + '  ');
+    
+    return `${indent}const ${factoryName} = (): RuleResult => {\n${indent}  return ${formattedResult};\n${indent}};`;
+  } catch (error) {
+    console.error('Error parsing RuleResult data:', error);
+    return `${indent}const ${factoryName} = (): RuleResult => {\n${indent}  // Error parsing RuleResult data\n${indent}  return {} as RuleResult;\n${indent}};`;
+  }
+};
+
+const generateDataCacheFactoryCode = (params: Record<string, string>, indent: string): string => {
+  const variableName = params.variableName || 'dataCache';
+  const dataCacheData = params.dataCacheData || '';
+  
+  if (!dataCacheData) {
+    return `${indent}const ${variableName}: DataCache = {};`;
+  }
+  
+  try {
+    const dataCache = JSON.parse(dataCacheData);
+    
+    const formatObject = (obj: unknown, currentIndent: string): string => {
+      if (obj === null) return 'null';
+      if (obj === undefined) return 'undefined';
+      if (typeof obj === 'string') return `'${obj.replace(/'/g, "\\'")}'`;
+      if (typeof obj === 'number' || typeof obj === 'boolean') return String(obj);
+      
+      if (Array.isArray(obj)) {
+        if (obj.length === 0) return '[]';
+        const items = obj.map(item => `${currentIndent}  ${formatObject(item, currentIndent + '  ')}`).join(',\n');
+        return `[\n${items},\n${currentIndent}]`;
+      }
+      
+      if (typeof obj === 'object') {
+        const entries = Object.entries(obj);
+        if (entries.length === 0) return '{}';
+        const props = entries.map(([key, value]) => {
+          const formattedValue = formatObject(value, currentIndent + '  ');
+          return `${currentIndent}  ${key}: ${formattedValue}`;
+        }).join(',\n');
+        return `{\n${props},\n${currentIndent}}`;
+      }
+      
+      return 'undefined';
+    };
+    
+    const formattedDataCache = formatObject(dataCache, indent);
+    
+    return `${indent}const ${variableName}: DataCache = ${formattedDataCache};`;
+  } catch (error) {
+    console.error('Error parsing DataCache data:', error);
+    return `${indent}const ${variableName}: DataCache = {};\n${indent}// Error parsing DataCache data`;
+  }
 };
 
 const generateSetVariableCode = (params: Record<string, string>, indent: string): string => {
@@ -805,6 +998,31 @@ const generateNodeCodeRecursive = (
     
     return [loopCode, exitCode].filter(Boolean).join('\n');
   }
+
+  if (nodeData.nodeType === 'Describe') {
+    const params = nodeData.params || {};
+    const describeName = params.describeName || 'test suite';
+    
+    const bodyNodes = getNodesInBranch(node.id, 'body', nodes, edges, new Set(processedNodes));
+    
+    // Mark body nodes as processed to prevent duplicate processing
+    bodyNodes.forEach((n) => processedNodes.add(n.id));
+
+    const innerCode = bodyNodes
+      .map((n) => generateNodeCodeRecursive(n, nodes, edges, indent + '  ', processedNodes))
+      .filter(Boolean)
+      .join('\n');
+
+    let describeCode = `${indent}describe('${describeName}', () => {\n`;
+    if (innerCode) {
+      describeCode += innerCode + '\n';
+    }
+    describeCode += `${indent}});`;
+
+    const exitCode = processExitEdge(node.id, nodes, edges, indent, processedNodes);
+    
+    return [describeCode, exitCode].filter(Boolean).join('\n');
+  }
   
   // For regular nodes
   const nodeCode = generateNodeCode(node, indent, nodes);
@@ -859,6 +1077,38 @@ const generateNestedFlowCode = (
       if (exitEdge) processNode(exitEdge.target);
       return;
     }
+
+    if (nodeData.nodeType === 'Describe') {
+      processedNodes.add(node.id);
+      const params = nodeData.params || {};
+      const describeName = params.describeName || 'test suite';
+
+      const bodyNodes = getNodesInBranch(node.id, 'body', nodes, edges, new Set(processedNodes));
+      
+      // Use a fresh processedNodes set for the body to allow nested describes
+      const bodyProcessedNodes = new Set<string>(processedNodes);
+      bodyNodes.forEach((n) => bodyProcessedNodes.add(n.id));
+
+      const innerCode = bodyNodes
+        .map((n) => generateNodeCodeRecursive(n, allNodes, edges, indent + '  ', bodyProcessedNodes))
+        .filter(Boolean)
+        .join('\n');
+
+      let describeCode = `${indent}describe('${describeName}', () => {\n`;
+      if (innerCode) {
+        describeCode += innerCode + '\n';
+      }
+      describeCode += `${indent}});`;
+      
+      codeLines.push(describeCode);
+      
+      // Mark all body nodes as processed in the main set too
+      bodyNodes.forEach((n) => processedNodes.add(n.id));
+      
+      const exitEdge = edges.find((e) => e.source === node.id && e.sourceHandle === 'exit');
+      if (exitEdge) processNode(exitEdge.target);
+      return;
+    }
     
     if (nodeData.nodeType === 'If') {
       try {
@@ -908,7 +1158,13 @@ const generateNestedFlowCode = (
       }
     } else {
       const code = generateNodeCode(node, indent, allNodes);
-      if (code) codeLines.push(code);
+      if (code) {
+        // Add consistent blank line between all statements (except the first)
+        if (codeLines.length > 0 && codeLines[codeLines.length - 1] !== '') {
+          codeLines.push('');
+        }
+        codeLines.push(code);
+      }
       
       const nextEdge = edges.find((e) => e.source === nodeId);
       if (nextEdge) processNode(nextEdge.target);
@@ -1038,4 +1294,13 @@ ${nestedCode}
 }`;
   
   return code;
+};
+
+export const generateTestCaseCode = (
+  nodes: Node[],
+  edges: Edge[],
+): string => {
+  const flowCode = generateNestedFlowCode(nodes, edges, '', nodes);
+  
+  return flowCode || '// Add nodes to the canvas to generate code';
 };

--- a/frontend/src/utils/Flow/transformRuleRequest.ts
+++ b/frontend/src/utils/Flow/transformRuleRequest.ts
@@ -1,0 +1,36 @@
+export const transformRuleRequestToCode = (ruleRequestData: unknown): string => {
+  if (!ruleRequestData || typeof ruleRequestData !== 'object') {
+    return `  const quote = {
+    transaction: JSON.parse(''),
+    networkMap: JSON.parse(''),
+    DataCache: JSON.parse(''),
+  };
+  return quote;`;
+  }
+
+  const data = ruleRequestData as Record<string, unknown>;
+  
+  const transaction = data.transaction || {};
+  const networkMap = data.networkMap || {};
+  const dataCache = data.DataCache || {};
+
+  const transactionStr = JSON.stringify(transaction);
+  const networkMapStr = JSON.stringify(networkMap);
+  const dataCacheStr = JSON.stringify(dataCache);
+
+  const escapeForTemplate = (str: string) => str.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$/g, '\\$');
+
+  return `  const quote = {
+    transaction: JSON.parse(
+      \`${escapeForTemplate(transactionStr)}\`,
+    ),
+    networkMap: JSON.parse(
+      '${networkMapStr.replace(/'/g, "\\'")}',
+    ),
+    DataCache: JSON.parse(
+      '${dataCacheStr.replace(/'/g, "\\'")}',
+    ),
+  };
+  return quote;`;
+};
+


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
This pull request introduces new features and improvements to the RuleBuilder UI, focusing on enhanced support for test case generation, node parameterization, and code editing capabilities. The changes add modal code editors for mock requests and setup code, extend node parameter support for various factory and service nodes, and improve component flexibility with new props for conditional UI rendering.

**Key changes include:**

### New code editing features

* Added a reusable `CodeEditorDialog` component using Monaco Editor, enabling modal code editing for node parameters such as mock requests and setup code.
* Integrated new `BeforeEachSection` and `BeforeAllSection` components to allow editing of setup code that runs before each or all test cases, with modal dialogs for code entry. [[1]](diffhunk://#diff-d76fa145a82d853b13a911c7213ceac447927c544128771bd410e9c521a32569R1-R27) [[2]](diffhunk://#diff-e3d9644ff9b95b8fc5a4240c84563b7a58134adc567594ecb8ea83c9b191a606R1-R27) [[3]](diffhunk://#diff-f332ba6d4b4788c8c1daffff25ba631a44e7f1064665b2245e9e8a7ae751a4beR1-R2)
* Added handlers and UI in `RightSidebar` for editing and saving mock requests, `beforeEach`, and `beforeAll` code, storing these as node parameters. [[1]](diffhunk://#diff-c9c389c6d9e213cd024766ec9e960ba2a0871992e48fa698f109abe833c416cbR69-R74) [[2]](diffhunk://#diff-c9c389c6d9e213cd024766ec9e960ba2a0871992e48fa698f109abe833c416cbR454-R516)

### Enhanced node parameterization

* Extended the `RightSidebar` to support parameter editing for new node types such as `RuleConfigFactory`, `RuleRequestFactory`, `RuleRequestScenario`, `RuleResultFactory`, `DataCacheFactory`, `DatabaseManager`, and `LoggerService`, each with their own parameter forms.

### Improved component flexibility and UI controls

* Added new props to key components to control UI behavior:
  - `mode` prop in `CanvasProps` and its usage in `RuleBuilderCanvas` for distinguishing between rule building and test case generation modes. [[1]](diffhunk://#diff-3db3fd7c0e2c2291cc594b334acc17b44bc646487d6905fb1cfdf7377e5da45bR69) [[2]](diffhunk://#diff-3db3fd7c0e2c2291cc594b334acc17b44bc646487d6905fb1cfdf7377e5da45bR89) [[3]](diffhunk://#diff-3db3fd7c0e2c2291cc594b334acc17b44bc646487d6905fb1cfdf7377e5da45bR172)
  - `hidePlayControls` in `Header` to optionally hide play/run controls. [[1]](diffhunk://#diff-5571e4295c3cc67f99208835ae5a2f49c6c05e2109e4c705549d8ba975c821dcR38) [[2]](diffhunk://#diff-5571e4295c3cc67f99208835ae5a2f49c6c05e2109e4c705549d8ba975c821dcR55) [[3]](diffhunk://#diff-5571e4295c3cc67f99208835ae5a2f49c6c05e2109e4c705549d8ba975c821dcR87-R88) [[4]](diffhunk://#diff-5571e4295c3cc67f99208835ae5a2f49c6c05e2109e4c705549d8ba975c821dcR154-R155)
  - `hideStartEnd` in `LeftSidebar` and passed through to the node palette hook. [[1]](diffhunk://#diff-c6feb3d0aac49315fae06cb76eae085ea84b573b4ab4d04a014a988381e45614R34) [[2]](diffhunk://#diff-c6feb3d0aac49315fae06cb76eae085ea84b573b4ab4d04a014a988381e45614R48) [[3]](diffhunk://#diff-c6feb3d0aac49315fae06cb76eae085ea84b573b4ab4d04a014a988381e45614L78-R80)

These updates collectively improve the test case generation workflow, make the UI more adaptable, and provide a richer editing experience for node configuration and setup code.

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done