### PR TITLE
Feat: Custom test Node

### DIFF
--- a/frontend/src/components/RuleBuilder/RightSidebar/components/ParameterFields/CodeTemplateButton.tsx
+++ b/frontend/src/components/RuleBuilder/RightSidebar/components/ParameterFields/CodeTemplateButton.tsx
@@ -53,7 +53,7 @@ const CodeTemplateButton: React.FC<CodeTemplateButtonProps> = ({
         >
           <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', flex: 1 }}>
             <Typography variant="body2" fontWeight={500}>
-              Edit Function Code
+              {input.key === 'code_template' ? 'Edit Function Code' : `Edit ${input.label}`}
             </Typography>
             <Typography variant="caption" color="text.secondary">
               {lineCount} lines of code

--- a/frontend/src/components/RuleBuilder/RightSidebar/components/ParameterSection.tsx
+++ b/frontend/src/components/RuleBuilder/RightSidebar/components/ParameterSection.tsx
@@ -93,13 +93,12 @@ const ParameterSection: React.FC<ParameterSectionProps> = ({
 
   const handleSaveCode = useCallback((code: string) => {
     if (editingCodeField) {
-      const syntheticEvent = {
-        target: { value: code }
-      } as React.ChangeEvent<HTMLInputElement>;
-      onParamChange(editingCodeField.key)(syntheticEvent);
-      onParamBlur?.();
+      const updatedParams = { ...currentParams, [editingCodeField.key]: code };
+      
+      onParamBlur?.(true, updatedParams);
     }
-  }, [editingCodeField, onParamChange, onParamBlur]);
+    handleCloseCodeModal();
+  }, [editingCodeField, currentParams, onParamBlur, handleCloseCodeModal]);
   
   const handleOpenQueryEditor = useCallback(() => {
     setQueryEditorOpen(true);
@@ -175,7 +174,7 @@ const ParameterSection: React.FC<ParameterSectionProps> = ({
     const isVariableNameField = nodeType === 'SetVariable' && ['name', 'variableName'].includes(input.key);
     const hasError = !!fieldError || (isVariableNameField && !!variableError);
     const isCodeField = ['code', 'loopBody', 'query', 'code_template', 'function_code'].includes(input.key);
-    const helperText = getHelperText(input, fieldError, isVariableNameField, isCodeField);
+    const helperText = getHelperText(input, fieldError, isVariableNameField, isCodeField || input.type === 'code');
 
 
     if (input.options && input.options.length > 0) {
@@ -238,7 +237,7 @@ const ParameterSection: React.FC<ParameterSectionProps> = ({
       );
     }
 
-    if (input.key === 'code_template') {
+    if (input.key === 'code_template' || input.type === 'code') {
       return (
         <CodeTemplateButton
           key={input.key}


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
This pull request enhances the flexibility and usability of the parameter fields in the Rule Builder's right sidebar, particularly around code-editing inputs. The changes make the UI more dynamic by supporting both `code_template` and generic code input types, and improve the handling of code parameter updates.

**Parameter field handling improvements:**

* Updated the save handler in `ParameterSection` to pass the updated parameter values directly to `onParamBlur`, ensuring more accurate state updates when editing code fields.
* Modified logic to treat both `code_template` and any parameter with `type === 'code'` as code fields, allowing for more flexible parameter configurations. [[1]](diffhunk://#diff-ffff471989aca41f211ffe0dc3fdd26ee6d09911519cdb0728eefb6f728e2779L178-R177) [[2]](diffhunk://#diff-ffff471989aca41f211ffe0dc3fdd26ee6d09911519cdb0728eefb6f728e2779L241-R240)

**User interface enhancements:**

* Changed the label in `CodeTemplateButton` to dynamically display either "Edit Function Code" or "Edit {input.label}", improving clarity for users editing different types of code fields.

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done