### PR TITLE
feat: update rule flow APIs for test case

### DIFF
--- a/backend/src/services/admin-service-client.ts
+++ b/backend/src/services/admin-service-client.ts
@@ -13,6 +13,8 @@ import {
   RuleFiltersDto,
   RequestFlow,
   RuleFlowFilterDto,
+  ResponseRuleFlow,
+  ResponseUpdatedRuleFlowDto,
 } from '../services/rules/dto/rules.dto';
 import { firstValueFrom } from 'rxjs';
 import {
@@ -361,11 +363,11 @@ async getAllNodes(
   async getRuleFlow(
     ruleId: string,
     token: string,
-    filters: RuleFlowFilterDto,
-  ): Promise<ResponseRuleFlowDto> {
-    return await this.executeHttpRequest<ResponseRuleFlowDto>(
+    filters?: RuleFlowFilterDto,
+  ): Promise<ResponseRuleFlow> {
+    return await this.executeHttpRequest<ResponseRuleFlow>(
       'GET',
-      `${RULE_FLOW}/${ruleId}${Object.keys(filters).length ? '?' + new URLSearchParams(filters as Record<string, string>).toString() : ''}`,
+      `${RULE_FLOW}/${ruleId}${filters && Object.keys(filters).length ? '?' + new URLSearchParams(filters as Record<string, string>).toString() : ''}`,
       token,
     );
   }
@@ -374,8 +376,8 @@ async getAllNodes(
     ruleId: string,
     payload: RequestSaveFlow,
     token: string,
-  ): Promise<ResponseRuleFlowDto> {
-    return await this.executeHttpRequest<ResponseRuleFlowDto>(
+  ): Promise<ResponseUpdatedRuleFlowDto> {
+    return await this.executeHttpRequest<ResponseUpdatedRuleFlowDto>(
       'PUT',
       `${RULE_FLOW}/${ruleId}`,
       token,

--- a/backend/src/services/rules/dto/rules.dto.ts
+++ b/backend/src/services/rules/dto/rules.dto.ts
@@ -9,6 +9,7 @@ import {
   ValidateNested,
   Matches,
   IsEnum,
+  IsBoolean,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
@@ -269,6 +270,38 @@ export class FlowDto {
   edges: FlowEdgeDto[];
 }
 
+
+export class ResponseUpdatedRuleFlowDto {
+  @ApiProperty({
+    description: 'Unique identifier for the rule flow',
+    example: 'flow-001',
+  })
+  @IsString()
+  id: string;
+
+  
+  @ApiProperty({
+    description: 'Identifier of the associated rule',
+    example: '01',
+  })
+  @IsString()
+  @IsNotEmpty()
+  rule_id: string;
+
+
+  @ApiProperty({ description: 'Flow structure', type: FlowDto })
+  @IsObject()
+  @IsNotEmpty()
+  flow_json: Record<string, unknown>;
+
+  @ApiProperty({
+    description: 'Base64 encoded TypeScript file representing the flow',
+    example:
+      'data:application/typescript;base64,ZXhwb3J0IGNvbnN0Li4u',
+  })
+  @IsString()
+  ts_file_base64: string;
+}
 export class ResponseRuleFlowDto {
   @ApiProperty({
     description: 'Unique identifier for the rule flow',
@@ -286,18 +319,47 @@ export class ResponseRuleFlowDto {
   rule_id: string;
 
 
-  @ApiProperty({ description: 'Flow structure of the rule', type: FlowDto })
+  @ApiProperty({ description: 'Flow structure of the rule builder if no category filter applied', type: FlowDto })
   @IsObject()
-  @IsNotEmpty()
-  flow: Record<string, unknown>;
+  @IsOptional()
+  flow_json_rule_builder?: Record<string, unknown>;
+
+  @ApiProperty({ description: 'Flow structure of the test case if no category filter applied', type: FlowDto })
+  @IsObject()
+  @IsOptional()
+  flow_json_test_case: Record<string, unknown>;
 
   @ApiProperty({
-    description: 'Base64 encoded TypeScript file representing the flow',
+    description: 'Base64 encoded TypeScript file representing the flow of the rule builder if no filter applied',
     example:
       'data:application/typescript;base64,ZXhwb3J0IGNvbnN0Li4u',
   })
   @IsString()
-  ts_file_base64: string;
+  @IsOptional()
+  ts_file_base64_rule_builder?: string;
+
+  @ApiProperty({
+    description: 'Base64 encoded TypeScript file representing the flow of the test case if no filter applied',
+    example:
+      'data:application/typescript;base64,ZXhwb3J0IGNvbnN0Li4u',
+  })
+  @IsString()
+  @IsOptional()
+  ts_file_base64_test_case?: string;
+
+   @ApiProperty({ description: 'Flow structure of the test case if category filter applied', type: FlowDto })
+  @IsObject()
+  @IsOptional()
+  flow_json: Record<string, unknown>;
+
+  @ApiProperty({
+    description: 'Base64 encoded TypeScript file representing the flow if category filter applied',
+    example:
+      'data:application/typescript;base64,ZXhwb3J0IGNvbnN0Li4u',
+  })
+  @IsString()
+  @IsOptional()
+  ts_file_base64?: string;
 }
 
 export class FlowNodeDto {
@@ -454,19 +516,20 @@ export class RequestSaveFlow {
 
 export class RequestFlow {
   @ApiProperty({
-    description: 'Category of the flow',
-    example: RuleCategory.RULE_BUILDER,
-  })
-  @IsEnum(RuleCategory)
-  @IsNotEmpty()
-  category: RuleCategory;
-
-  @ApiProperty({
     description: 'Json of the flow',
     example: '{"edges": {}, "nodes": {} }',
   })
   @IsObject()
-  flow_json: Record<string, unknown>;
+  flow_json_rule_builder: Record<string, unknown>;
+
+  @ApiProperty({
+    description: 'Json of the test case flow',
+    example: '{"edges": {}, "nodes": {} }',
+  })
+  @IsObject()
+  flow_json_test_case: Record<string, unknown>;
+
+
 }
 
 export class RuleFlowFilterDto {
@@ -477,4 +540,19 @@ export class RuleFlowFilterDto {
   @IsOptional()
   @IsEnum(RuleCategory)
   category?: RuleCategory;
+}
+
+export class ResponseRuleFlow {
+  @ApiProperty({
+    description: 'Status of the API response indicating success or failure',
+  })
+  @IsString()
+  status: string;
+
+  @ApiProperty({
+    description: 'Response of the rule flow retrieval operation',
+    type: ResponseRuleFlowDto,
+  })
+  @IsObject()
+  result: ResponseRuleFlowDto;
 }

--- a/backend/src/services/rules/rules.controller.ts
+++ b/backend/src/services/rules/rules.controller.ts
@@ -38,6 +38,8 @@ import {
   CreateRuleDto,
   RequestFlow,
   RuleFlowFilterDto,
+  ResponseRuleFlow,
+  ResponseUpdatedRuleFlowDto,
 } from './dto/rules.dto';
 
 @ApiTags('Rules')
@@ -333,7 +335,7 @@ export class RulesController {
     @Param('ruleId') ruleId: string,
     @Query() query: RuleFlowFilterDto,
     @User() user: AuthenticatedUser,
-  ): Promise<ResponseRuleFlowDto> {
+  ): Promise<ResponseRuleFlow> {
     const result = await this.rulesService.getRuleFlow(
       ruleId,
       user.token.tokenString,
@@ -363,7 +365,7 @@ export class RulesController {
     @Param('ruleId') ruleId: string,
     @Body() payload: RequestSaveFlow,
     @User() user: AuthenticatedUser,
-  ): Promise<ResponseRuleFlowDto> {
+  ): Promise<ResponseUpdatedRuleFlowDto> {
     return await this.rulesService.updateRuleFlow(
       ruleId,
       payload,

--- a/backend/src/services/rules/rules.service.ts
+++ b/backend/src/services/rules/rules.service.ts
@@ -8,6 +8,8 @@ import {
   RuleFiltersDto,
   RequestFlow,
   RuleFlowFilterDto,
+  ResponseRuleFlow,
+  ResponseUpdatedRuleFlowDto,
 } from './dto/rules.dto';
 import { ParseExtractService } from '../parse-extract/parse-extract.service';
 import { TransactionalMessage } from '../parse-extract/dto/message.dto';
@@ -104,36 +106,22 @@ export class RulesService {
       const rule = await this.adminServiceClient.createRule(cleanRuleData, token);
       let updatedRule = rule;
       if (rule.id) {
-        const baseRuleBuilderFlow = await this.adminServiceClient.getRuleFlow(
+        const baseRuleFlow = await this.getRuleFlow(
           BASE_RULE_ID,
           token,
-          { category: RuleCategory.RULE_BUILDER },
         );
-        // const baseTestCaseFlow = await this.adminServiceClient.getRuleFlow(
-        //   BASE_RULE_ID,
-        //   token,
-        //   { category: RuleCategory.TEST_CASE },
-        // );
-        const newRuleBuilderFlow = await this.adminServiceClient.createRuleFlow(
+        const newRuleFlow = await this.adminServiceClient.createRuleFlow(
           rule.id,
-          { 
-            category: RuleCategory.RULE_BUILDER,
-            flow_json: baseRuleBuilderFlow.flow,
+          {
+            flow_json_rule_builder: baseRuleFlow.result.flow_json_rule_builder ? baseRuleFlow.result.flow_json_rule_builder : {},
+            flow_json_test_case: baseRuleFlow.result.flow_json_test_case ? baseRuleFlow.result.flow_json_test_case : {},
           },
           token,
         );
-        // const newTestCaseFlow = await this.adminServiceClient.createRuleFlow(
-        //   rule.id,
-        //   { 
-        //     category: RuleCategory.TEST_CASE,
-        //     flow_json: baseTestCaseFlow.flow,
-        //   },
-        //   token,
-        // );
-        if (newRuleBuilderFlow) {
+        if (newRuleFlow) {
           updatedRule = await this.adminServiceClient.updateRule(
             rule.id,
-            { flow_id: newRuleBuilderFlow.id },
+            { flow_id: newRuleFlow.id },
             token,
           );
         } else {
@@ -205,10 +193,12 @@ export class RulesService {
   async getRuleFlow(
     ruleId: string,
     token: string,
-    filters: RuleFlowFilterDto,
-  ): Promise<ResponseRuleFlowDto> {
+    filters?: RuleFlowFilterDto,
+  ): Promise<ResponseRuleFlow>
+   {
     try {
-      return await this.adminServiceClient.getRuleFlow(ruleId, token, filters);
+      const ruleFlow = await this.adminServiceClient.getRuleFlow(ruleId, token, filters);
+      return ruleFlow;
     } catch (error) {
       const err = error as Error;
       this.logger.error(
@@ -242,7 +232,7 @@ export class RulesService {
     ruleId: string,
     payload: RequestSaveFlow,
     token: string,
-  ): Promise<ResponseRuleFlowDto> {
+  ): Promise<ResponseUpdatedRuleFlowDto> {
     try {
       return await this.adminServiceClient.updateRuleFlow(
         ruleId,

--- a/backend/test/rules/rules.service.spec.ts
+++ b/backend/test/rules/rules.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { RulesService } from '../../src/services/rules/rules.service';
 import { AdminServiceClient } from '../../src/services/admin-service-client';
 import { Logger } from '@nestjs/common';
+import { RuleCategory } from 'src/utils/enums/rule.enum';
 
 describe('RulesService', () => {
   let service: RulesService;
@@ -296,9 +297,12 @@ describe('RulesService', () => {
 
   describe('getRuleFlow', () => {
     it('should return rule flow', async () => {
-      const mockRuleFlow = { flowId: 'flow-123', steps: [], connections: [] };
-
-      adminServiceClient.getRuleFlow.mockResolvedValue(mockRuleFlow);
+      const mockRuleFlow = { id: 'flow-123', flow_json_rule_builder: { steps: [], connections: [] }, rule_id: 'rule-123', tenant_id: 'tenant-123', ts_file_base64_rule_builder: 'dGVzdC1maWxlLWRhdGE=', flow_json_test_case: { cases: [] }, ts_file_base64_test_case: 'dGVzdC1maWxlLWRhdGE=', flow_json: {}, ts_file_base64: '' };
+      const mockResponseRuleFlow = {
+        status: '200',
+        result: mockRuleFlow,
+      };
+      adminServiceClient.getRuleFlow.mockResolvedValue(mockResponseRuleFlow);
 
       const result = await service.getRuleFlow('rule-123', 'test-token');
 
@@ -325,15 +329,14 @@ describe('RulesService', () => {
 
   describe('createRuleFlow', () => {
     it('should create rule flow', async () => {
-      const mockFlowData = { steps: ['step1', 'step2'], connections: [] };
-      const mockRequestBody = { flowData: mockFlowData };
-      const mockCreatedFlow = { flowId: 'flow-123', ...mockFlowData };
-
-      adminServiceClient.createRuleFlow.mockResolvedValue(mockCreatedFlow);
+      const mockFlowData = { flow_json_rule_builder: { steps: ['step1', 'step2'], connections: [] }, flow_json_test_case: { cases: [] } };
+      const mockRuleFlow = { id: 'flow-123', flow_json_rule_builder: { steps: [], connections: [] }, rule_id: 'rule-123', tenant_id: 'tenant-123', ts_file_base64_rule_builder: 'dGVzdC1maWxlLWRhdGE=', flow_json_test_case: { cases: [] }, ts_file_base64_test_case: 'dGVzdC1maWxlLWRhdGE=', flow_json: {}, ts_file_base64: '' };
+      
+      adminServiceClient.createRuleFlow.mockResolvedValue(mockRuleFlow);
 
       const result = await service.createRuleFlow(
         'rule-123',
-        mockRequestBody,
+        mockFlowData,
         'test-token',
       );
 
@@ -342,7 +345,7 @@ describe('RulesService', () => {
         mockFlowData,
         'test-token',
       );
-      expect(result).toEqual(mockCreatedFlow);
+      expect(result).toEqual(mockRuleFlow);
     });
 
     it('should handle flow creation error', async () => {
@@ -351,7 +354,7 @@ describe('RulesService', () => {
       adminServiceClient.createRuleFlow.mockRejectedValue(mockError);
 
       await expect(
-        service.createRuleFlow('rule-123', { flowData: {} }, 'test-token'),
+        service.createRuleFlow('rule-123', { flow_json_rule_builder: { steps: ['step1', 'step2'], connections: [] }, flow_json_test_case: { cases: [] } }, 'test-token'),
       ).rejects.toThrow('Flow creation failed');
       expect(Logger.prototype.error).toHaveBeenCalledWith(
         'Error creating flow for rule rule-123: Flow creation failed',
@@ -362,11 +365,15 @@ describe('RulesService', () => {
   describe('updateRuleFlow', () => {
     it('should update rule flow', async () => {
       const mockPayload = {
-        flowId: 'flow-123',
-        steps: ['updated-step'],
-        connections: [],
+        category: RuleCategory.RULE_BUILDER,
+        flow_json: {
+          flowId: 'flow-123',
+          steps: ['updated-step'],
+          connections: [],
+        },
+        ts_file_base64: 'dGVzdC1maWxlLWRhdGE=',
       };
-      const mockUpdatedFlow = { ...mockPayload };
+      const mockUpdatedFlow = { ...mockPayload, id: '1', tenant_id: 'tenant-123', rule_id: 'rule-123' };
 
       adminServiceClient.updateRuleFlow.mockResolvedValue(mockUpdatedFlow);
 
@@ -390,7 +397,15 @@ describe('RulesService', () => {
       adminServiceClient.updateRuleFlow.mockRejectedValue(mockError);
 
       await expect(
-        service.updateRuleFlow('rule-123', {}, 'test-token'),
+        service.updateRuleFlow('rule-123', {
+          category: RuleCategory.RULE_BUILDER,
+          flow_json: {
+            flowId: 'flow-123',
+            steps: ['updated-step'],
+            connections: [],
+          },
+          ts_file_base64: 'dGVzdC1maWxlLWRhdGE=',
+        }, 'test-token'),
       ).rejects.toThrow('Flow update failed');
       expect(Logger.prototype.error).toHaveBeenCalledWith(
         'Error updating flow for rule rule-123: Flow update failed',


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
DB Changes (trs_rule_flow):

• Renamed
```
ts_file_base64 → ts_file_base64_rule_builder
flow_json → flow_json_rule_builder
```

• Added
```
ts_file_base64_test_case (TEXT – base64 TS for test cases)
flow_json_test_case (JSON – test case flow)
```

API Impact:
• createRuleFlow / updateRuleFlow / getRuleFlow now support both:

*_rule_builder
*_test_case
• Flow and TS data returned based on category (rule_builder or test_case_generation).
• createRule and cloneRule request/response remain the same, but service logic now also handles flow creation/cloning using the new schema.This change enables clear separation between rule-building logic and test-case-generation flows.

## Why are we doing this?

## How was it tested?
- [x] Locally
- [x] Development Environment
- [x] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done