### PR TITLE
Feat paysys status flow

### DIFF
--- a/frontend/src/components/RuleBuilder/Canvas/index.tsx
+++ b/frontend/src/components/RuleBuilder/Canvas/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef, useEffect } from 'react';
+import React, { useState, useCallback, useRef, useEffect, memo } from 'react';
 import type { DragEvent } from 'react';
 import {
   ReactFlow,
@@ -30,6 +30,11 @@ const nodeTypes = {
   editableNode: EditableNode,
 };
 
+const EMPTY_NESTED_DATA: Record<string, NestedCanvasData> = {};
+const EMPTY_DEBUG_VARS: Record<string, unknown> = {};
+const EMPTY_DEBUG_LOGS: DebugLog[] = [];
+const DEFAULT_VIEWPORT = { x: 150, y: 50, zoom: 1 };
+
 const UpdateNodeInternalsExposer: React.FC<{ onReady: (updateFn: (nodeId: string) => void) => void }> = ({ onReady }) => {
   const updateNodeInternals = useUpdateNodeInternals();
   
@@ -53,6 +58,7 @@ interface CanvasProps {
   onNodeUpdateHandlerReady?: (handler: (nodeId: string, updates: Record<string, unknown>) => void) => void;
   debugVariables?: Record<string, unknown>;
   debugLogs?: DebugLog[];
+  isNestedCanvasActive?: boolean;
   currentNodeId?: string;
   nestedCanvasData?: Record<string, NestedCanvasData>;
   onFlowStateUpdate?: (
@@ -70,15 +76,16 @@ interface CanvasProps {
 
 
 
-const RuleBuilderCanvas: React.FC<CanvasProps> = ({ 
+const RuleBuilderCanvas: React.FC<CanvasProps> = memo(({
   isPlaying, 
   onJsonGenerate, 
   onCodeGenerate,
   onNodeSelect,
   onNodeUpdateHandlerReady,
-  nestedCanvasData = {},
-  debugVariables = {},
-  debugLogs = [],
+  nestedCanvasData = EMPTY_NESTED_DATA,
+  debugVariables = EMPTY_DEBUG_VARS,
+  debugLogs = EMPTY_DEBUG_LOGS,
+  isNestedCanvasActive = false,
   currentNodeId,
   onFlowStateUpdate,
   viewOnly = false,
@@ -87,34 +94,24 @@ const RuleBuilderCanvas: React.FC<CanvasProps> = ({
   onUpdateNodeInternalsReady,
   mode = 'rule-builder',
 }) => {
-  const initialDataRef = useRef({ nodes: initialNodes, edges: initialEdges });
   const extractedNestedCountersRef = useRef(false);
+  const hasInitializedStateRef = useRef(false);
   
-  const getInitialFlow = React.useMemo(() => {
-    const nodes = (initialDataRef.current.nodes as Node[]) || [];
-    const edges = (initialDataRef.current.edges as Edge[]) || [];
-    return { nodes, edges };
-  }, []);
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
 
-  const hasNestedFlows = React.useMemo(() => {
-    return nestedCanvasData ? Object.keys(nestedCanvasData).length > 0 : false;
-  }, [nestedCanvasData]);
-  
   useEffect(() => {
-    const { nodes, edges } = getInitialFlow;
-    
-    if ((nodes.length > 0 || edges.length > 0) && hasNestedFlows && !extractedNestedCountersRef.current) {
-      extractCountersFromFlow(nodes, edges, nestedCanvasData || {});
-      extractedNestedCountersRef.current = true;
-    } else if ((nodes.length > 0 || edges.length > 0) && !hasNestedFlows && !extractedNestedCountersRef.current) {
-      extractCountersFromFlow(nodes, edges, {});
+    if (!hasInitializedStateRef.current && initialNodes && initialNodes.length > 0 && initialEdges) {
+      setNodes(initialNodes);
+      setEdges(initialEdges);
+      hasInitializedStateRef.current = true;
+
+      const hasNestedFlows = nestedCanvasData ? Object.keys(nestedCanvasData).length > 0 : false;
+      extractCountersFromFlow(initialNodes, initialEdges, hasNestedFlows ? (nestedCanvasData || {}) : {});
       extractedNestedCountersRef.current = true;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasNestedFlows]);
-
-  const [nodes, setNodes, onNodesChange] = useNodesState(getInitialFlow.nodes);
-  const [edges, setEdges, onEdgesChange] = useEdgesState(getInitialFlow.edges);
+  }, [initialNodes, initialEdges]);
   
   const onFlowStateUpdateRef = useRef(onFlowStateUpdate);
 
@@ -122,48 +119,38 @@ const RuleBuilderCanvas: React.FC<CanvasProps> = ({
     onFlowStateUpdateRef.current = onFlowStateUpdate;
   }, [onFlowStateUpdate]);
 
-  const prevInitialNodesRef = useRef<Node[] | undefined>(undefined);
-  const prevInitialEdgesRef = useRef<Edge[] | undefined>(undefined);
-  
-  useEffect(() => {
-    if (initialNodes !== undefined && initialNodes !== prevInitialNodesRef.current) {
-      prevInitialNodesRef.current = initialNodes;
-      setNodes(initialNodes);
-    }
-  }, [initialNodes, setNodes]);
-
-  useEffect(() => {
-    if (initialEdges !== undefined && initialEdges !== prevInitialEdgesRef.current) {
-      prevInitialEdgesRef.current = initialEdges;
-      setEdges(initialEdges);
-    }
-  }, [initialEdges, setEdges]);
-
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance | null>(null);
 
+  const saveHistoryNoOp = useCallback(() => {}, []);
+
   const nodeOps = useCanvasNodeOperations({
     setNodes,
-    saveHistory: () => {},
+    saveHistory: saveHistoryNoOp,
     setEdges,
   });
+
+  const deleteSelectedNodesCallback = useCallback(() => {
+    const selectedNodes = nodes.filter((n) => n.selected);
+    setNodes((currentNodes) => nodeOps.deleteSelectedNodes(currentNodes, selectedNodes));
+    
+    if (onNodeSelect && selectedNodes.length > 0) {
+      onNodeSelect(null);
+    }
+  }, [nodes, setNodes, nodeOps, onNodeSelect]);
+
+  const deleteSelectedEdgesCallback = useCallback(() => {
+    setEdges((currentEdges) => nodeOps.deleteSelectedEdges(currentEdges));
+  }, [setEdges, nodeOps]);
 
   const { pushHistory } = useCanvasKeyboardShortcuts({
     nodes,
     edges,
     setNodes,
     setEdges,
-    deleteSelectedNodes: () => {
-      const selectedNodes = nodes.filter((n) => n.selected);
-      setNodes((currentNodes) => nodeOps.deleteSelectedNodes(currentNodes, selectedNodes));
-      
-      if (onNodeSelect && selectedNodes.length > 0) {
-        onNodeSelect(null);
-      }
-    },
-    deleteSelectedEdges: () => {
-      setEdges((currentEdges) => nodeOps.deleteSelectedEdges(currentEdges));
-    },
+    deleteSelectedNodes: deleteSelectedNodesCallback,
+    deleteSelectedEdges: deleteSelectedEdgesCallback,
+    enabled: !isNestedCanvasActive,
   });
 
   const { createNodeFromTemplate: createNode, updateNode: update } =
@@ -223,9 +210,15 @@ const RuleBuilderCanvas: React.FC<CanvasProps> = ({
     }
   }, [onNodeUpdateHandlerReady, handleNodeUpdate]);
 
+  const nodesLengthRef = useRef(nodes.length);
+  const edgesLengthRef = useRef(edges.length);
+
   React.useEffect(() => {
-    if (onFlowStateUpdateRef.current) {
+    if (onFlowStateUpdateRef.current && 
+        (nodesLengthRef.current !== nodes.length || edgesLengthRef.current !== edges.length)) {
       onFlowStateUpdateRef.current(nodes, edges, setNodes, setEdges);
+      nodesLengthRef.current = nodes.length;
+      edgesLengthRef.current = edges.length;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [nodes, edges]);
@@ -289,7 +282,7 @@ const RuleBuilderCanvas: React.FC<CanvasProps> = ({
           onNodeClick={onNodeClick}
           onPaneClick={onPaneClick}
           nodeTypes={nodeTypes}
-          defaultViewport={{ x: 150, y: 50, zoom: 1 }}
+          defaultViewport={DEFAULT_VIEWPORT}
           nodesDraggable={!isPlaying && !viewOnly}
           nodesConnectable={!isPlaying && !viewOnly}
           elementsSelectable={!isPlaying && !viewOnly}
@@ -396,6 +389,8 @@ const RuleBuilderCanvas: React.FC<CanvasProps> = ({
     )}
     </Box>
   );
-};
+});
+
+RuleBuilderCanvas.displayName = 'RuleBuilderCanvas';
 
 export default RuleBuilderCanvas;

--- a/frontend/src/components/RuleBuilder/Header/index.tsx
+++ b/frontend/src/components/RuleBuilder/Header/index.tsx
@@ -36,6 +36,8 @@ interface HeaderProps {
   disabled?: boolean;
   viewOnly?: boolean;
   hidePlayControls?: boolean;
+  title?: string;
+  backUrl?: string;
 }
 
 const Header: React.FC<HeaderProps> = ({
@@ -53,6 +55,8 @@ const Header: React.FC<HeaderProps> = ({
   disabled = false,
   viewOnly = false,
   hidePlayControls = false,
+  title = 'Rule Builder',
+  backUrl = '/editor?tab=rule_builder',
 }) => {
   const { hasErrors, getErrorCount } = useValidationContext();
   const navigate = useNavigate();
@@ -65,7 +69,7 @@ const Header: React.FC<HeaderProps> = ({
         <Box display="flex" alignItems="center" gap={1}>
           <Tooltip title="Back to Editor">
             <IconButton
-              onClick={() => navigate('/editor?tab=rule_builder')}
+              onClick={() => navigate(backUrl)}
               color="primary"
               size="medium"
             >
@@ -79,7 +83,7 @@ const Header: React.FC<HeaderProps> = ({
             fontWeight={600}
             color="text.primary"
           >
-            Rule Builder {viewOnly && '(View Only)'}
+            {title} {viewOnly && '(View Only)'}
           </Typography>
         </Box>
 

--- a/frontend/src/components/RuleBuilder/NestedCanvas/index.tsx
+++ b/frontend/src/components/RuleBuilder/NestedCanvas/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import React, { useState, useCallback, useRef, useEffect, useMemo, memo } from 'react';
 import type { DragEvent } from 'react';
 import {
   ReactFlow,
@@ -20,13 +20,16 @@ import EditableNode from '../EditableNode';
 import LeftSidebar from '../LeftSidebar';
 import RightSidebar from '../RightSidebar';
 import { getNodeTemplate } from '../../../utils/Flow/nodeTemplateService';
-import { generateNestedNodeId, setCounters } from '../../../utils/Flow/FlowDefaults';
+import { generateNestedNodeId, setNestedNodeCounter } from '../../../utils/Flow/FlowDefaults';
 import { getLabelForHandle, getColorForHandle } from '../../../utils/Common/helpers';
 import { useValidationContext } from '../../../validation/context';
 
 const nodeTypes = {
   editableNode: EditableNode,
 };
+
+const EMPTY_MAIN_CANVAS_NODES: Node[] = [];
+const DEFAULT_NESTED_VIEWPORT = { x: 150, y: 50, zoom: 1 };
 
 const UpdateNodeInternalsExposer: React.FC<{ onReady: (updateFn: (nodeId: string) => void) => void }> = ({ onReady }) => {
   const updateNodeInternals = useUpdateNodeInternals();
@@ -50,7 +53,7 @@ interface NestedCanvasProps {
   mainCanvasNodes?: Node[];
 }
 
-const NestedCanvas: React.FC<NestedCanvasProps> = ({
+const NestedCanvas: React.FC<NestedCanvasProps> = memo(({
   nodeLabel,
   initialNodes: providedInitialNodes,
   initialEdges: providedInitialEdges,
@@ -58,7 +61,7 @@ const NestedCanvas: React.FC<NestedCanvasProps> = ({
   onSave,
   viewOnly = false,
   ruleId,
-  mainCanvasNodes = [],
+  mainCanvasNodes = EMPTY_MAIN_CANVAS_NODES,
 }) => {
   const [initialNodesEdges] = useState(() => {
     if (providedInitialNodes) {
@@ -71,7 +74,7 @@ const NestedCanvas: React.FC<NestedCanvasProps> = ({
         return max;
       }, 0);
       if (maxNestedNodeId > 0) {
-        setCounters(0, 0, maxNestedNodeId);
+        setNestedNodeCounter(maxNestedNodeId);
       }
       
       return { nodes: providedInitialNodes, edges: providedInitialEdges || [] };
@@ -126,6 +129,7 @@ const NestedCanvas: React.FC<NestedCanvasProps> = ({
   const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance | null>(null);
   const updateNodeInternalsRef = useRef<((nodeId: string) => void) | null>(null);
   const { clearNodeErrors } = useValidationContext();
+  const hasNestedInitializedRef = useRef(false);
   
   const nodesRef = useRef(nodes);
   const edgesRef = useRef(edges);
@@ -141,22 +145,16 @@ const NestedCanvas: React.FC<NestedCanvasProps> = ({
     edgesRef.current = edges;
   }, [nodes, edges]);
 
-  const prevProvidedNodesRef = useRef<Node[] | undefined>(undefined);
-  const prevProvidedEdgesRef = useRef<Edge[] | undefined>(undefined);
-  
   useEffect(() => {
-    if (providedInitialNodes !== undefined && providedInitialNodes !== prevProvidedNodesRef.current) {
-      prevProvidedNodesRef.current = providedInitialNodes;
+    if (!hasNestedInitializedRef.current && providedInitialNodes && providedInitialNodes.length > 0) {
       setNodes(providedInitialNodes);
+      if (providedInitialEdges) {
+        setEdges(providedInitialEdges);
+      }
+      hasNestedInitializedRef.current = true;
     }
-  }, [providedInitialNodes, setNodes]);
-
-  useEffect(() => {
-    if (providedInitialEdges !== undefined && providedInitialEdges !== prevProvidedEdgesRef.current) {
-      prevProvidedEdgesRef.current = providedInitialEdges;
-      setEdges(providedInitialEdges);
-    }
-  }, [providedInitialEdges, setEdges]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [providedInitialNodes, providedInitialEdges]);
   
   const allNodes = useMemo(() => {
     return [...mainCanvasNodes, ...nodes];
@@ -474,7 +472,7 @@ const NestedCanvas: React.FC<NestedCanvasProps> = ({
             onNodeClick={onNodeClick}
             onPaneClick={onPaneClick}
             nodeTypes={nodeTypes}
-            defaultViewport={{ x: 150, y: 50, zoom: 1 }}
+            defaultViewport={DEFAULT_NESTED_VIEWPORT}
             nodesDraggable={!viewOnly}
             nodesConnectable={!viewOnly}
             elementsSelectable={!viewOnly}
@@ -500,6 +498,9 @@ const NestedCanvas: React.FC<NestedCanvasProps> = ({
       </Box>
     </Box>
   );
-};
+});
+
+NestedCanvas.displayName = 'NestedCanvas';
 
 export default NestedCanvas;
+

--- a/frontend/src/hooks/RuleBuilder/useCanvasKeyboardShortcuts.ts
+++ b/frontend/src/hooks/RuleBuilder/useCanvasKeyboardShortcuts.ts
@@ -8,6 +8,7 @@ interface UseCanvasKeyboardShortcutsProps {
   setEdges: (edges: Edge[] | ((prevEdges: Edge[]) => Edge[])) => void;
   deleteSelectedNodes: () => void;
   deleteSelectedEdges: () => void;
+  enabled?: boolean;
 }
 
 export const useCanvasKeyboardShortcuts = ({
@@ -17,6 +18,7 @@ export const useCanvasKeyboardShortcuts = ({
   setEdges,
   deleteSelectedNodes,
   deleteSelectedEdges,
+  enabled = true,
 }: UseCanvasKeyboardShortcutsProps) => {
   const historyRef = useRef<{ nodes: Node[]; edges: Edge[] }[]>([]);
   const redoRef = useRef<{ nodes: Node[]; edges: Edge[] }[]>([]);
@@ -71,9 +73,11 @@ export const useCanvasKeyboardShortcuts = ({
     ]
   );
   useEffect(() => {
+    if (!enabled) return;
+    
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [onKeyDown]);
+  }, [onKeyDown, enabled]);
 
   const pushHistory = useCallback(() => {
     historyRef.current.push({ nodes: [...nodes], edges: [...edges] });

--- a/frontend/src/hooks/RuleBuilder/useFlowState.ts
+++ b/frontend/src/hooks/RuleBuilder/useFlowState.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import type { Node } from '@xyflow/react';
 import type { DebugLog } from '../../components/RuleBuilder/DebuggerPanel';
 
@@ -77,7 +77,7 @@ export const useFlowState = () => {
     URL.revokeObjectURL(url);
   }, []);
 
-  return {
+  return useMemo(() => ({
     jsonModalOpen,
     setJsonModalOpen,
     codeModalOpen,
@@ -107,5 +107,28 @@ export const useFlowState = () => {
     handleJsonGenerate,
     handleCodeGenerate,
     handleDownload,
-  };
+  }), [
+    jsonModalOpen,
+    codeModalOpen,
+    jsonOutput,
+    codeOutput,
+    debugVariables,
+    setDebugVariables,
+    debugLogs,
+    setDebugLogs,
+    currentAnimationNode,
+    setCurrentAnimationNode,
+    selectedNode,
+    sidebarCollapsed,
+    generatedCode,
+    allNodes,
+    setAllNodes,
+    edges,
+    setEdges,
+    handleToggleSidebar,
+    handleCloseRightSidebar,
+    handleJsonGenerate,
+    handleCodeGenerate,
+    handleDownload,
+  ]);
 };

--- a/frontend/src/pages/RuleEditor/RuleBuilder/index.tsx
+++ b/frontend/src/pages/RuleEditor/RuleBuilder/index.tsx
@@ -1,11 +1,12 @@
-import { Box, Grid } from "@mui/material"
+import { Box, Grid, Paper, CircularProgress } from "@mui/material"
 import Button from "../../../components/Button"
 import useRuleBuilderController, { type IRuleBuilder } from "./useRuleBuilderController"
 import { Text } from "../../../components/Text";
 
 const RuleBuilder = (props: IRuleBuilder) => {
 
-    const { functions } = useRuleBuilderController(props);
+    const { values, functions } = useRuleBuilderController(props);
+    const { statusConfig, isLoadingFlow } = values;
 
     return (
         <Grid
@@ -13,24 +14,61 @@ const RuleBuilder = (props: IRuleBuilder) => {
             py={3}
             height={'60vh'}
         >
-            <Box>
-                <Grid size={12} >
+            <Box width={'100%'}>
+                <Grid size={12} mb={1}>
                     <Text weight={'bold'} color="black" size={'header'}>Rule Builder</Text>
                 </Grid>
-                <Grid size={12} >
-                    <Text color="text.ternary" size={'body'}>Create Your Rule</Text>
+                <Grid size={12} mb={3}>
+                    <Text color="text.ternary" size={'body'}>Create and manage your rule flow</Text>
                 </Grid>
             </Box>
-            <Box width={'100%'} display={'flex'} justifyContent={'center'}>
-                <Button
-                    height="40px"
-                    width="170px"
-                    type="secondary"
-                    size="md"
-                    text="Open Rule Builder"
-                    onClick={functions.handleBuilder}
-                />
-            </Box>
+            
+            {isLoadingFlow ? (
+                <Box width={'100%'} display={'flex'} justifyContent={'center'} alignItems={'center'} flex={1}>
+                    <CircularProgress />
+                </Box>
+            ) : (
+                <Box width={'100%'} display={'flex'} justifyContent={'center'} alignItems={'center'} flex={1}>
+                    <Paper
+                        elevation={0}
+                        sx={{
+                            backgroundColor: statusConfig.bgColor,
+                            border: `2px solid ${statusConfig.color}`,
+                            borderRadius: '12px',
+                            padding: '32px',
+                            maxWidth: '600px',
+                            width: '100%',
+                            textAlign: 'center'
+                        }}
+                    >
+                        <Box fontSize={'48px'} mb={2}>
+                            {statusConfig.icon}
+                        </Box>
+                        <Text 
+                            weight={'bold'} 
+                            size={'subHeader'} 
+                            sx={{ color: statusConfig.color, mb: 2 }}
+                        >
+                            {statusConfig.title}
+                        </Text>
+                        <Text 
+                            color="text.secondary" 
+                            size={'body'}
+                            sx={{ mb: 3, display: 'block' }}
+                        >
+                            {statusConfig.description}
+                        </Text>
+                        <Button
+                            height="44px"
+                            width="180px"
+                            type="secondary"
+                            size="md"
+                            text={statusConfig.buttonText}
+                            onClick={functions.handleBuilder}
+                        />
+                    </Paper>
+                </Box>
+            )}
             <Box width={'100%'} display={'flex'} justifyContent={'space-between'} alignSelf={'flex-end'}>
                 <Button
                     height="40px"

--- a/frontend/src/pages/RuleEditor/RuleBuilder/useRuleBuilderController.ts
+++ b/frontend/src/pages/RuleEditor/RuleBuilder/useRuleBuilderController.ts
@@ -3,6 +3,7 @@ import { extractData } from "../../../utils/Common/storage";
 import { LocalStorage } from "../../../utils/Common/enums";
 import { useTab } from "../../../contexts/TabContext/useTab";
 import { useMemo } from "react";
+import { useGetRuleFlowStatusQuery } from "../../../redux/Api/Rule-builder";
 
 export interface IRuleBuilder {
     data?: Record<string, unknown> | undefined
@@ -11,9 +12,14 @@ export interface IRuleBuilder {
 const useRuleBuilderController = (props: IRuleBuilder) => {
 
     const data = useMemo(
-        () => extractData('trs_rule', LocalStorage, true) ?? props?.data,
-        [props?.data]
+        () => extractData('trs_rule', LocalStorage, true) ?? props.data,
+        [props.data]
     )
+
+    const { data: flowData, isLoading: isLoadingFlow } = useGetRuleFlowStatusQuery(
+        { ruleId: (data?.id || '') as string | number, category: 'rule_builder' },
+        { skip: !data?.id, refetchOnMountOrArgChange: true }
+    );
 
     const { enableNextTab, enablePreviousTab } = useTab()
 
@@ -30,8 +36,63 @@ const useRuleBuilderController = (props: IRuleBuilder) => {
         enablePreviousTab()
     }
 
+    const flowStatus = flowData?.result?.status || 'initial'
+    const isInitial = flowStatus === 'initial'
+    const isPassed = flowStatus === 'pass'
+    const isFailed = flowStatus === 'fail'
+
+    const getStatusConfig = () => {
+        switch (flowStatus) {
+            case 'initial':
+                return {
+                    title: 'Rule Not Created Yet',
+                    description: 'Your rule is in initial mode. Click the button below to start building your rule.',
+                    buttonText: 'Open Rule Builder',
+                    color: '#FFA726',
+                    bgColor: '#FFF3E0',
+                    icon: '🚀'
+                }
+            case 'pass':
+                return {
+                    title: 'Rule Validated Successfully',
+                    description: 'Your rule has been validated and is ready to use. You can edit it anytime.',
+                    buttonText: 'Edit Rule',
+                    color: '#66BB6A',
+                    bgColor: '#E8F5E9',
+                    icon: '✅'
+                }
+            case 'fail':
+                return {
+                    title: 'Validation Failed',
+                    description: 'Your rule contains errors and needs to be fixed. Click below to review and correct the issues.',
+                    buttonText: 'Edit Rule',
+                    color: '#EF5350',
+                    bgColor: '#FFEBEE',
+                    icon: '⚠️'
+                }
+            default:
+                return {
+                    title: 'Rule Builder',
+                    description: 'Create your rule',
+                    buttonText: 'Open Rule Builder',
+                    color: '#42A5F5',
+                    bgColor: '#E3F2FD',
+                    icon: '📝'
+                }
+        }
+    }
+
+    const statusConfig = getStatusConfig()
+
     return {
-        values: {},
+        values: {
+            flowStatus,
+            isInitial,
+            isPassed,
+            isFailed,
+            isLoadingFlow,
+            statusConfig
+        },
         functions: {
             handleBuilder,
             handleNext,

--- a/frontend/src/pages/RuleEditor/RuleBuilder/useRuleBuilderController.ts
+++ b/frontend/src/pages/RuleEditor/RuleBuilder/useRuleBuilderController.ts
@@ -1,4 +1,3 @@
-import { useNavigate } from "react-router-dom";
 import { extractData } from "../../../utils/Common/storage";
 import { LocalStorage } from "../../../utils/Common/enums";
 import { useTab } from "../../../contexts/TabContext/useTab";
@@ -23,10 +22,8 @@ const useRuleBuilderController = (props: IRuleBuilder) => {
 
     const { enableNextTab, enablePreviousTab } = useTab()
 
-    const navigate = useNavigate()
-
     const handleBuilder = () => {
-        navigate(`/rule-builder/${data?.id}`)
+        window.location.href = `/rule-builder/${data?.id}`
     }
 
     const handleNext = () => {

--- a/frontend/src/pages/RuleEditor/TestCases/index.tsx
+++ b/frontend/src/pages/RuleEditor/TestCases/index.tsx
@@ -1,11 +1,12 @@
-import { Box, Grid } from "@mui/material";
+import { Box, Grid, Paper, CircularProgress } from "@mui/material";
 import Button from "../../../components/Button";
 import useTestCasesController, { type ITestCases } from "./useTestCasesController";
 import { Text } from "../../../components/Text";
 
 const TestCases = (props: ITestCases) => {
 
-    const { functions } = useTestCasesController(props);
+    const { values, functions } = useTestCasesController(props);
+    const { statusConfig, isLoadingFlow } = values;
 
     return (
         <Grid
@@ -13,24 +14,61 @@ const TestCases = (props: ITestCases) => {
             py={3}
             height={'60vh'}
         >
-            <Box>
-                <Grid size={12} >
+            <Box width={'100%'}>
+                <Grid size={12} mb={1}>
                     <Text weight={'bold'} color="black" size={'header'}>Generate Test Cases</Text>
                 </Grid>
-                <Grid size={12} >
-                    <Text color="text.ternary" size={'body'}>Add Test Cases Of Your Rule</Text>
+                <Grid size={12} mb={3}>
+                    <Text color="text.ternary" size={'body'}>Create and manage your test cases</Text>
                 </Grid>
             </Box>
-            <Box width={'100%'} display={'flex'} justifyContent={'center'}>
-                <Button
-                    height="40px"
-                    width="220px"
-                    type="secondary"
-                    size="md"
-                    text="Open Test Case Generator"
-                    onClick={functions.handleCanvas}
-                />
-            </Box>
+            
+            {isLoadingFlow ? (
+                <Box width={'100%'} display={'flex'} justifyContent={'center'} alignItems={'center'} flex={1}>
+                    <CircularProgress />
+                </Box>
+            ) : (
+                <Box width={'100%'} display={'flex'} justifyContent={'center'} alignItems={'center'} flex={1}>
+                    <Paper
+                        elevation={0}
+                        sx={{
+                            backgroundColor: statusConfig.bgColor,
+                            border: `2px solid ${statusConfig.color}`,
+                            borderRadius: '12px',
+                            padding: '32px',
+                            maxWidth: '600px',
+                            width: '100%',
+                            textAlign: 'center'
+                        }}
+                    >
+                        <Box fontSize={'48px'} mb={2}>
+                            {statusConfig.icon}
+                        </Box>
+                        <Text 
+                            weight={'bold'} 
+                            size={'subHeader'} 
+                            sx={{ color: statusConfig.color, mb: 2 }}
+                        >
+                            {statusConfig.title}
+                        </Text>
+                        <Text 
+                            color="text.secondary" 
+                            size={'body'}
+                            sx={{ mb: 3, display: 'block' }}
+                        >
+                            {statusConfig.description}
+                        </Text>
+                        <Button
+                            height="44px"
+                            width="220px"
+                            type="secondary"
+                            size="md"
+                            text={statusConfig.buttonText}
+                            onClick={functions.handleCanvas}
+                        />
+                    </Paper>
+                </Box>
+            )}
             <Box width={'100%'} display={'flex'} justifyContent={'space-between'} alignSelf={'flex-end'}>
                 <Button
                     height="40px"

--- a/frontend/src/pages/RuleEditor/TestCases/useTestCasesController.ts
+++ b/frontend/src/pages/RuleEditor/TestCases/useTestCasesController.ts
@@ -1,8 +1,8 @@
-import { useNavigate } from "react-router-dom";
 import { useTab } from "../../../contexts/TabContext/useTab";
 import { useMemo } from "react";
 import { extractData } from "../../../utils/Common/storage";
 import { LocalStorage } from "../../../utils/Common/enums";
+import { useGetRuleFlowStatusQuery } from "../../../redux/Api/Rule-builder";
 
 
 export interface ITestCases {
@@ -16,8 +16,12 @@ const useTestCasesController = (props: ITestCases) => {
         [props?.data]
     )
 
+    const { data: flowData, isLoading: isLoadingFlow } = useGetRuleFlowStatusQuery(
+        { ruleId: (data?.id || '') as string | number, category: 'test_case_generation' },
+        { skip: !data?.id, refetchOnMountOrArgChange: true }
+    );
+
     const { enableNextTab, enablePreviousTab } = useTab()
-    const navigate = useNavigate()
 
     const handleNext = () => {
         enableNextTab()
@@ -28,11 +32,66 @@ const useTestCasesController = (props: ITestCases) => {
     }
 
     const handleCanvas = () => {
-        navigate(`/test-case-generate/${data?.id}`)
+        window.location.href = `/test-case-generate/${data?.id}`
     }
 
+    const flowStatus = flowData?.result?.status || 'initial'
+    const isInitial = flowStatus === 'initial'
+    const isPassed = flowStatus === 'pass'
+    const isFailed = flowStatus === 'fail'
+
+    const getStatusConfig = () => {
+        switch (flowStatus) {
+            case 'initial':
+                return {
+                    title: 'Test Cases Not Created Yet',
+                    description: 'Your test cases are in initial mode. Click the button below to start generating test cases.',
+                    buttonText: 'Open Test Case Generator',
+                    color: '#FFA726',
+                    bgColor: '#FFF3E0',
+                    icon: '🚀'
+                }
+            case 'pass':
+                return {
+                    title: 'Test Cases Validated Successfully',
+                    description: 'Your test cases have been validated and are ready to use. You can edit them anytime.',
+                    buttonText: 'Edit Test Cases',
+                    color: '#66BB6A',
+                    bgColor: '#E8F5E9',
+                    icon: '✅'
+                }
+            case 'fail':
+                return {
+                    title: 'Validation Failed',
+                    description: 'Your test cases contain errors and need to be fixed. Click below to review and correct the issues.',
+                    buttonText: 'Edit Test Cases',
+                    color: '#EF5350',
+                    bgColor: '#FFEBEE',
+                    icon: '⚠️'
+                }
+            default:
+                return {
+                    title: 'Test Case Generator',
+                    description: 'Generate test cases for your rule',
+                    buttonText: 'Open Test Case Generator',
+                    color: '#42A5F5',
+                    bgColor: '#E3F2FD',
+                    icon: '📝'
+                }
+        }
+    }
+
+    const statusConfig = getStatusConfig()
+
     return {
-        values: {},
+        values: {
+            flowStatus,
+            isInitial,
+            isPassed,
+            isFailed,
+            isLoadingFlow,
+            statusConfig
+        },
         functions: {
             handleNext,
             handleCanvas,

--- a/frontend/src/pages/rule-builder/index.tsx
+++ b/frontend/src/pages/rule-builder/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useCallback, useMemo } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@mui/material';
 import { useParams } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import type { Node, Edge } from '@xyflow/react';
@@ -76,9 +76,12 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
   }, [transformedFlowData]);
 
   const [showErrorModal, setShowErrorModal] = React.useState(false);
+  const [showSaveSuccessModal, setShowSaveSuccessModal] = React.useState(false);
+  const [allowNavigation, setAllowNavigation] = React.useState(false);
 
   useEffect(() => {
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (allowNavigation) return;
       event.preventDefault();
       event.returnValue = '';
       return '';
@@ -89,7 +92,7 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
-  }, []);
+  }, [allowNavigation]);
   
   const [isPaused, setIsPaused] = React.useState(false);
   
@@ -185,13 +188,17 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
         status,
       };
 
-      const response = await saveFlow({
+      await saveFlow({
         ruleId,
         flowData: payload,
         category: 'rule_builder',
       }).unwrap();
 
-      toast.success(response.message || 'Flow saved successfully');
+      // Close JSON modal but keep code modal open
+      flowState.setJsonModalOpen(false);
+      
+      // Show save success modal (code modal stays open in background)
+      setShowSaveSuccessModal(true);
     } catch (error: unknown) {
       const errorMessage = (error as { data?: { message?: string } })?.data?.message || 'Failed to save flow';
       toast.error(errorMessage);
@@ -279,6 +286,8 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
         isSaving={isSaving}
         viewOnly={viewOnly}
         hidePlayControls={true}
+        title="Rule Builder"
+        backUrl="/editor?tab=rule_builder"
       />
       {nodesError || flowError ? (
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', flex: 1, flexDirection: 'column', gap: 2 }}>
@@ -391,6 +400,37 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
         open={showErrorModal}
         onClose={() => setShowErrorModal(false)}
       />
+
+      <Dialog open={showSaveSuccessModal} onClose={() => setShowSaveSuccessModal(false)}>
+        <DialogTitle>Flow Saved Successfully</DialogTitle>
+        <DialogContent>
+          <Typography>Your rule flow has been saved. What would you like to do next?</Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button 
+            onClick={() => {
+              setShowSaveSuccessModal(false);
+              // Keep code modal open when staying on editor
+            }} 
+            variant="outlined"
+          >
+            Stay on Editor
+          </Button>
+          <Button 
+            onClick={() => {
+              setShowSaveSuccessModal(false);
+              flowState.setCodeModalOpen(false);
+              setAllowNavigation(true);
+              setTimeout(() => {
+                window.location.href = '/editor?tab=rule_builder';
+              }, 0);
+            }} 
+            variant="contained"
+          >
+            Proceed to Next Step
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 };

--- a/frontend/src/pages/rule-builder/index.tsx
+++ b/frontend/src/pages/rule-builder/index.tsx
@@ -14,6 +14,7 @@ import { ValidationErrorModal } from '../../components/RuleBuilder/ValidationErr
 import { useGetFlowQuery, useSaveFlowMutation, useGetNodesQuery } from '../../redux/Api/Rule-builder';
 import { transformApiFlowData, type ApiNode, type ApiEdge } from '../../utils/Flow/FlowTransformers';
 import { setApiNodes } from '../../utils/Flow/nodeTemplateService';
+import { validateTypeScriptCode } from '../../utils/Flow/codeValidator';
 import {
   useFlowAnimation,
   useFlowState,
@@ -31,7 +32,7 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
   
   const { data: flowData, isLoading: isLoadingFlow, error: flowError } = useGetFlowQuery(
     { ruleId: ruleId || '', category: 'rule_builder' },
-    { skip: !ruleId }
+    { skip: !ruleId, refetchOnMountOrArgChange: true }
   );
   
   const [saveFlow, { isLoading: isSaving }] = useSaveFlowMutation();
@@ -173,11 +174,15 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
         return;
       }
 
+      const validationResult = validateTypeScriptCode(tsCode);
+      const status = validationResult.isValid ? 'pass' : 'fail';
+
       const tsFileBase64 = btoa(unescape(encodeURIComponent(tsCode)));
 
       const payload = {
         flow_json: parsedFlowJson,
         ts_file_base64: tsFileBase64,
+        status,
       };
 
       const response = await saveFlow({
@@ -224,8 +229,7 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
     updateNodeInternalsRef.current?.(nodeId);
   }, []);
 
-  const handleFlowStateUpdate = ((
-    nodes: Node[], 
+  const handleFlowStateUpdate = useCallback((    nodes: Node[], 
     edges: Edge[], 
     setNodes: (nodes: Node[] | ((prevNodes: Node[]) => Node[])) => void, 
     setEdges: (edges: Edge[] | ((prevEdges: Edge[]) => Edge[])) => void
@@ -233,13 +237,22 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
     updateFlowState(nodes, edges, setNodes, setEdges);
     flowState.setAllNodes(nodes);
     flowState.setEdges(edges);
-  });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [updateFlowState, flowState.setAllNodes, flowState.setEdges]);
   
-  const handleNestedCanvasSave = ((nodes: Node[], edges: Edge[]) => {
+  const handleNestedCanvasSave = useCallback((nodes: Node[], edges: Edge[]) => {
     if (nestedCanvasManager.activeNestedCanvas) {
       nestedCanvasManager.handleNestedCanvasSave(nestedCanvasManager.activeNestedCanvas, nodes, edges);
     }
-  });
+  }, [nestedCanvasManager]);
+
+  const canvasWrapperStyle = useMemo(() => ({
+    display: nestedCanvasManager.activeNestedCanvas ? 'none' : 'flex',
+    flex: 1,
+    flexDirection: 'column' as const,
+    height: '100%',
+    width: '100%'
+  }), [nestedCanvasManager.activeNestedCanvas]);
 
   useEffect(() => {
     const timeoutRef = animationTimeoutRef.current;
@@ -305,23 +318,25 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({ viewOnly = false }) => {
               ruleId={ruleId}
             />
           )}
-          <RuleBuilderCanvas
-            key={nestedCanvasManager.activeNestedCanvas ? 'hidden' : 'main-canvas'}
-            isPlaying={Boolean(flowState.currentAnimationNode)}
-            onJsonGenerate={flowState.handleJsonGenerate}
-            onCodeGenerate={flowState.handleCodeGenerate}
-            onNodeSelect={handleNodeSelect}
-            onNodeUpdateHandlerReady={handleNodeUpdateHandlerReady}
-            debugVariables={flowState.debugVariables}
-            debugLogs={flowState.debugLogs}
-            currentNodeId={flowState.currentAnimationNode}
-            nestedCanvasData={nestedCanvasManager.nestedCanvasData}
-            viewOnly={viewOnly}
-            onFlowStateUpdate={handleFlowStateUpdate}
-            initialNodes={transformedFlowData?.nodes}
-            initialEdges={transformedFlowData?.edges}
-            onUpdateNodeInternalsReady={handleUpdateNodeInternalsReady}
-          />
+          <Box sx={canvasWrapperStyle}>
+            <RuleBuilderCanvas
+              isPlaying={Boolean(flowState.currentAnimationNode)}
+              onJsonGenerate={flowState.handleJsonGenerate}
+              onCodeGenerate={flowState.handleCodeGenerate}
+              onNodeSelect={handleNodeSelect}
+              onNodeUpdateHandlerReady={handleNodeUpdateHandlerReady}
+              debugVariables={flowState.debugVariables}
+              debugLogs={flowState.debugLogs}
+              currentNodeId={flowState.currentAnimationNode}
+              nestedCanvasData={nestedCanvasManager.nestedCanvasData}
+              viewOnly={viewOnly}
+              onFlowStateUpdate={handleFlowStateUpdate}
+              initialNodes={transformedFlowData?.nodes}
+              initialEdges={transformedFlowData?.edges}
+              onUpdateNodeInternalsReady={handleUpdateNodeInternalsReady}
+              isNestedCanvasActive={Boolean(nestedCanvasManager.activeNestedCanvas)}
+            />
+          </Box>
           <RightSidebar
             key={flowState.selectedNode?.id || 'no-selection'}
             selectedNode={flowState.selectedNode}

--- a/frontend/src/pages/test-case-generate/index.tsx
+++ b/frontend/src/pages/test-case-generate/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useCallback, useState, useMemo } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@mui/material';
 import { useParams } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import type { Node, Edge } from '@xyflow/react';
@@ -13,6 +13,7 @@ import { ValidationErrorModal } from '../../components/RuleBuilder/ValidationErr
 import { useGetNodesQuery, useSaveFlowMutation, useGetGlobalVariablesQuery, useGetFlowQuery } from '../../redux/Api/Rule-builder';
 import { setApiNodes } from '../../utils/Flow/nodeTemplateService';
 import { transformApiFlowData, type ApiNode as ApiFlowNode, type ApiEdge } from '../../utils/Flow/FlowTransformers';
+import { validateTypeScriptCode } from '../../utils/Flow/codeValidator';
 import { useFlowState } from '../../hooks/RuleBuilder';
 
 interface TestCaseGenerateProps {
@@ -28,8 +29,9 @@ const TestCaseGenerate: React.FC<TestCaseGenerateProps> = ({ viewOnly = false })
   });
   const { data: flowData } = useGetFlowQuery(
     { ruleId: ruleId || '', category: 'test_case_generation' },
-    { skip: !ruleId }
+    { skip: !ruleId, refetchOnMountOrArgChange: true }
   );
+
   const [saveFlow, { isLoading: isSaving }] = useSaveFlowMutation();
   
   const flowState = useFlowState();
@@ -58,9 +60,12 @@ const TestCaseGenerate: React.FC<TestCaseGenerateProps> = ({ viewOnly = false })
   }, [globalVariablesData]);
 
   const [showErrorModal, setShowErrorModal] = useState<boolean>(false);
+  const [showSaveSuccessModal, setShowSaveSuccessModal] = useState<boolean>(false);
+  const [allowNavigation, setAllowNavigation] = useState<boolean>(false);
 
   useEffect(() => {
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (allowNavigation) return;
       event.preventDefault();
       event.returnValue = '';
       return '';
@@ -71,7 +76,7 @@ const TestCaseGenerate: React.FC<TestCaseGenerateProps> = ({ viewOnly = false })
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
-  }, []);
+  }, [allowNavigation]);
 
   const nodeUpdateHandlerRef = useRef<((nodeId: string, updates: Record<string, unknown>) => void) | null>(null);
 
@@ -110,38 +115,37 @@ const TestCaseGenerate: React.FC<TestCaseGenerateProps> = ({ viewOnly = false })
         return;
       }
 
+      const validationResult = validateTypeScriptCode(tsCode);
+      const status = validationResult.isValid ? 'pass' : 'fail';
+
       const tsFileBase64 = btoa(unescape(encodeURIComponent(tsCode)));
 
       const payload = {
         flow_json: parsedFlowJson,
         ts_file_base64: tsFileBase64,
+        status,
       };
 
-      const response = await saveFlow({
+      await saveFlow({
         ruleId,
         flowData: payload,
         category: 'test_case_generation',
       }).unwrap();
 
-      toast.success(response.message || 'Test case flow saved successfully');
+      flowState.setJsonModalOpen(false);
+      setShowSaveSuccessModal(true);
     } catch (error: unknown) {
       const errorMessage = (error as { data?: { message?: string } })?.data?.message || 'Failed to save test case';
       toast.error(errorMessage);
     }
-  }, [ruleId, saveFlow]);
-
-  const flowStateRef = useRef(flowState);
-  
-  useEffect(() => {
-    flowStateRef.current = flowState;
-  }, [flowState]);
+  }, [ruleId, saveFlow, flowState]);
 
   const handleNodeSelect = useCallback((node: Node | null) => {
     if (node?.data.nodeType === 'Start' || node?.data.nodeType === 'End') {
       return;
     }
-    flowStateRef.current.setSelectedNode(node);
-  }, []);
+    flowState.setSelectedNode(node);
+  }, [flowState]);
 
   const handleNodeUpdateHandlerReady = useCallback((handler: (nodeId: string, updates: Record<string, unknown>) => void) => {
     nodeUpdateHandlerRef.current = handler;
@@ -163,9 +167,9 @@ const TestCaseGenerate: React.FC<TestCaseGenerateProps> = ({ viewOnly = false })
     nodes: Node[], 
     edges: Edge[]
   ) => {
-    flowStateRef.current.setAllNodes(nodes);
-    flowStateRef.current.setEdges(edges);
-  }, []);
+    flowState.setAllNodes(nodes);
+    flowState.setEdges(edges);
+  }, [flowState]);
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden' }}>
@@ -179,6 +183,8 @@ const TestCaseGenerate: React.FC<TestCaseGenerateProps> = ({ viewOnly = false })
         onSave={handleSave}
         isSaving={isSaving}
         viewOnly={viewOnly}
+        title="Test Cases Generation"
+        backUrl="/editor?tab=test_cases"
       />
       {nodesError ? (
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', flex: 1, flexDirection: 'column', gap: 2 }}>
@@ -268,6 +274,37 @@ const TestCaseGenerate: React.FC<TestCaseGenerateProps> = ({ viewOnly = false })
         open={showErrorModal}
         onClose={() => setShowErrorModal(false)}
       />
+
+      <Dialog open={showSaveSuccessModal} onClose={() => setShowSaveSuccessModal(false)}>
+        <DialogTitle>Test Cases Saved Successfully</DialogTitle>
+        <DialogContent>
+          <Typography>Your test case flow has been saved. What would you like to do next?</Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button 
+            onClick={() => {
+              setShowSaveSuccessModal(false);
+              // Keep code modal open when staying on editor
+            }} 
+            variant="outlined"
+          >
+            Stay on Editor
+          </Button>
+          <Button 
+            onClick={() => {
+              setShowSaveSuccessModal(false);
+              flowState.setCodeModalOpen(false);
+              setAllowNavigation(true);
+              setTimeout(() => {
+                window.location.href = '/editor?tab=test_cases';
+              }, 0);
+            }} 
+            variant="contained"
+          >
+            Proceed to Next Step
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 };

--- a/frontend/src/redux/Api/Rule-builder/index.ts
+++ b/frontend/src/redux/Api/Rule-builder/index.ts
@@ -47,6 +47,12 @@ export const ruleBuilderApi = createApi({
                 body: queryData,
             }),
         }),
+        getRuleFlowStatus: builder.query({
+            query: ({ ruleId, category = 'rule_builder' }: { ruleId: string | number; category?: string }) => ({
+                url: `rules/api/${ruleId}/flow/status?category=${category}`,
+                method: "GET",
+            }), 
+        })
     }),
 })
 
@@ -56,4 +62,5 @@ export const {
     useSaveFlowMutation,
     useGetGlobalVariablesQuery,
     useExecuteQueryMutation,
+    useGetRuleFlowStatusQuery
 } = ruleBuilderApi

--- a/frontend/src/utils/Flow/FlowDefaults.ts
+++ b/frontend/src/utils/Flow/FlowDefaults.ts
@@ -32,6 +32,10 @@ export const setCounters = (nodeCount: number, edgeCount: number, nestedNodeCoun
   nestedNodeCounter = nestedNodeCount;
 };
 
+export const setNestedNodeCounter = (nestedNodeCount: number) => {
+  nestedNodeCounter = Math.max(nestedNodeCounter, nestedNodeCount);
+};
+
 export const extractCountersFromFlow = (nodes: Node[], edges: Edge[], nestedCanvasData: Record<string, { nodes: Node[], edges: Edge[] }>) => {
   let maxNodeId = 0;
   let maxEdgeId = 0;


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
This pull request introduces several improvements and refactors to the Rule Builder canvas and nested canvas components, focusing on state initialization, keyboard shortcut control, and code maintainability. It also enhances header configurability and optimizes React component usage. The most important changes are grouped below:

**Canvas and Nested Canvas Improvements:**

* Refactored state initialization logic in `RuleBuilderCanvas` and `NestedCanvas` to use refs for tracking initialization, ensuring nodes and edges are set only once on mount and preventing repeated resets. This also removes redundant effects and simplifies the initialization code. [[1]](diffhunk://#diff-3db3fd7c0e2c2291cc594b334acc17b44bc646487d6905fb1cfdf7377e5da45bL90-R153) [[2]](diffhunk://#diff-709e2e435be5b9b3fd55e65097c7e9643db2f8134a3aa9a15c5640decc23a0b3L144-R157)
* Added `memo` to both `RuleBuilderCanvas` and `NestedCanvas` components to optimize rendering and set explicit `displayName` properties for better debugging. [[1]](diffhunk://#diff-3db3fd7c0e2c2291cc594b334acc17b44bc646487d6905fb1cfdf7377e5da45bL1-R1) [[2]](diffhunk://#diff-709e2e435be5b9b3fd55e65097c7e9643db2f8134a3aa9a15c5640decc23a0b3L1-R1) [[3]](diffhunk://#diff-3db3fd7c0e2c2291cc594b334acc17b44bc646487d6905fb1cfdf7377e5da45bL399-R394) [[4]](diffhunk://#diff-709e2e435be5b9b3fd55e65097c7e9643db2f8134a3aa9a15c5640decc23a0b3L503-R506)
* Introduced empty constant defaults for props like `nestedCanvasData`, `debugVariables`, `debugLogs`, and `mainCanvasNodes` to prevent unnecessary re-renders and improve code clarity. [[1]](diffhunk://#diff-3db3fd7c0e2c2291cc594b334acc17b44bc646487d6905fb1cfdf7377e5da45bR33-R37) [[2]](diffhunk://#diff-3db3fd7c0e2c2291cc594b334acc17b44bc646487d6905fb1cfdf7377e5da45bL73-R88) [[3]](diffhunk://#diff-709e2e435be5b9b3fd55e65097c7e9643db2f8134a3aa9a15c5640decc23a0b3L23-R33) [[4]](diffhunk://#diff-709e2e435be5b9b3fd55e65097c7e9643db2f8134a3aa9a15c5640decc23a0b3L53-R64)
* Centralized viewport defaults with `DEFAULT_VIEWPORT` and `DEFAULT_NESTED_VIEWPORT` constants for consistency across canvases. [[1]](diffhunk://#diff-3db3fd7c0e2c2291cc594b334acc17b44bc646487d6905fb1cfdf7377e5da45bR33-R37) [[2]](diffhunk://#diff-709e2e435be5b9b3fd55e65097c7e9643db2f8134a3aa9a15c5640decc23a0b3L23-R33) [[3]](diffhunk://#diff-3db3fd7c0e2c2291cc594b334acc17b44bc646487d6905fb1cfdf7377e5da45bL292-R285) [[4]](diffhunk://#diff-709e2e435be5b9b3fd55e65097c7e9643db2f8134a3aa9a15c5640decc23a0b3L477-R475)

**Keyboard Shortcut Control:**

* Enhanced `useCanvasKeyboardShortcuts` hook to accept an `enabled` prop, allowing keyboard shortcuts to be conditionally disabled (e.g., when a nested canvas is active). This prevents unwanted keyboard actions in certain contexts. [[1]](diffhunk://#diff-8a23ec3d8f8622d97313fbd58f33a39fdd9858fb63b82ef8eb2358045c414c0eR11) [[2]](diffhunk://#diff-8a23ec3d8f8622d97313fbd58f33a39fdd9858fb63b82ef8eb2358045c414c0eR21) [[3]](diffhunk://#diff-8a23ec3d8f8622d97313fbd58f33a39fdd9858fb63b82ef8eb2358045c414c0eR76-R80) [[4]](diffhunk://#diff-3db3fd7c0e2c2291cc594b334acc17b44bc646487d6905fb1cfdf7377e5da45bR61) [[5]](diffhunk://#diff-3db3fd7c0e2c2291cc594b334acc17b44bc646487d6905fb1cfdf7377e5da45bL73-R88) [[6]](diffhunk://#diff-3db3fd7c0e2c2291cc594b334acc17b44bc646487d6905fb1cfdf7377e5da45bL90-R153)

**Header Component Enhancements:**

* Made the `Header` component more flexible by adding `title` and `backUrl` props, allowing dynamic titles and navigation targets instead of hardcoded values. [[1]](diffhunk://#diff-5571e4295c3cc67f99208835ae5a2f49c6c05e2109e4c705549d8ba975c821dcR39-R40) [[2]](diffhunk://#diff-5571e4295c3cc67f99208835ae5a2f49c6c05e2109e4c705549d8ba975c821dcR58-R59) [[3]](diffhunk://#diff-5571e4295c3cc67f99208835ae5a2f49c6c05e2109e4c705549d8ba975c821dcL68-R72) [[4]](diffhunk://#diff-5571e4295c3cc67f99208835ae5a2f49c6c05e2109e4c705549d8ba975c821dcL82-R86)

**State Management Optimization:**

* Updated `useFlowState` hook to return a `useMemo`-ized object, preventing unnecessary re-renders when using the hook's returned values. [[1]](diffhunk://#diff-1e7ee35d035e85324f50364fd0fefb156a0435f4019bac2d7a6311b0db19a96dL1-R1) [[2]](diffhunk://#diff-1e7ee35d035e85324f50364fd0fefb156a0435f4019bac2d7a6311b0db19a96dL80-R80) [[3]](diffhunk://#diff-1e7ee35d035e85324f50364fd0fefb156a0435f4019bac2d7a6311b0db19a96dL110-R133)

**Code Consistency and Minor Refactors:**

* Renamed `setCounters` to `setNestedNodeCounter` for clarity and single-responsibility in nested node ID management. [[1]](diffhunk://#diff-709e2e435be5b9b3fd55e65097c7e9643db2f8134a3aa9a15c5640decc23a0b3L23-R33) [[2]](diffhunk://#diff-709e2e435be5b9b3fd55e65097c7e9643db2f8134a3aa9a15c5640decc23a0b3L74-R77)
* Improved update logic for `onFlowStateUpdate` to only trigger when the number of nodes or edges actually changes, reducing unnecessary updates.

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done