### PR TITLE
Fix: Fix rule config on edit

### DIFF
--- a/frontend/src/pages/RuleEditor/Overview/useOverviewController.tsx
+++ b/frontend/src/pages/RuleEditor/Overview/useOverviewController.tsx
@@ -160,6 +160,12 @@ const useOverviewController = (props: IOverviewProps) => {
 
     useEffect(() => {
         if (data) {
+            setValue('rule_config_id', toDropdown(data?.rule_config_id as string) as { label: string, value: string } | null)
+            setValue('rule_type', toDropdown(data?.rule_type as string) as { label: string, value: string } | null)
+            setValue('txtp', toDropdown(data?.txtp as string) as { label: string, value: string } | null)
+            setValue('txtpVersion', toDropdown(data?.txtp_version as string) as { label: string, value: string } | null)
+            setValue('version', (data?.version as string) ?? '')
+            setValue('description', (data?.description as string) ?? '')
             const name = getRuleName(data?.rule_config_id as string)
             setValue('rule_name', name)
         }

--- a/frontend/src/redux/Api/Rules/index.ts
+++ b/frontend/src/redux/Api/Rules/index.ts
@@ -68,6 +68,7 @@ export const rulesApi = createApi({
                 method: "GET",
                 providesTags: ['rule']
             }),
+            transformResponse: (response: Record<string, unknown>) => ({ rules: response }),
         }),
         getRuleConfigsIds: builder.query({
             query: () => ({


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
This pull request makes improvements to how rule data is handled and displayed in the Rule Editor's overview page. The most significant changes involve normalizing API responses and ensuring form fields are populated with correctly formatted dropdown values when editing rule details.

**Rule Editor Form Handling:**

* In `useOverviewController.tsx`, the form fields for `rule_config_id`, `rule_type`, `txtp`, and `txtpVersion` are now set using the `toDropdown` utility to ensure they have the correct dropdown format. Additionally, `version` and `description` are set with fallback defaults.

**API Response Normalization:**

* In `frontend/src/redux/Api/Rules/index.ts`, a `transformResponse` function was added to the `getRules` endpoint to wrap the response in a `rules` property, standardizing the data structure for downstream consumers.

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rule editor form field synchronization to properly update all configuration fields when editing a rule.
  * Improved rule retrieval API response structure for consistent data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->