### PR TITLE
fix: createRule interface missmatch

### DIFF
--- a/backend/src/services/rules/dto/rules.dto.ts
+++ b/backend/src/services/rules/dto/rules.dto.ts
@@ -41,7 +41,7 @@ export class RuleBaseDto {
   @IsNotEmpty()
   ruleName: string;
 
-  @ApiProperty({ description: 'Rule name', example: 'cbe-rule-061' })
+  @ApiPropertyOptional({ description: 'Rule name', example: 'cbe-rule-061' })
   @IsString()
   @IsOptional()
   rule_name?: string | undefined;

--- a/backend/src/services/rules/dto/rules.dto.ts
+++ b/backend/src/services/rules/dto/rules.dto.ts
@@ -43,6 +43,7 @@ export class RuleBaseDto {
 
   @ApiProperty({ description: 'Rule name', example: 'cbe-rule-061' })
   @IsString()
+  @IsOptional()
   rule_name?: string | undefined;
 
   @ApiProperty({ description: 'Rule description', example: 'Detects transactions above threshold' })


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The rule name field is now optional when creating or updating rules, preventing validation errors if omitted and aligning API documentation to indicate the field may be left out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->