### PR TITLE
Fix: Modify payload of Single Rule Simulation

### DIFF
--- a/frontend/src/pages/RuleEditor/Simulation/useSimulationController.tsx
+++ b/frontend/src/pages/RuleEditor/Simulation/useSimulationController.tsx
@@ -338,8 +338,8 @@ const useSimulationController = (props: ISimulation) => {
             body = {
                 functionName: '',
                 awaitReply: true,
-                destination: `sub-rule-${tenant_id}-rule-${id}@${version}`,
-                consumer: `pub-rule-${tenant_id}-rule-${id}@${version}`,
+                destination: `sub-rule-${id}@${version}`,
+                consumer: `pub-rule-${id}@${version}`,
                 message: parsedPayload
             };
             mutation = ruleOnly;

--- a/frontend/src/pages/RuleEditor/Simulation/useSimulationController.tsx
+++ b/frontend/src/pages/RuleEditor/Simulation/useSimulationController.tsx
@@ -29,7 +29,7 @@ const useSimulationController = (props: ISimulation) => {
         [props.data]
     )
 
-    const { tenant_id, rule_name } : { tenant_id?: string, rule_name?: string } = data || {};
+    const { rule_name } : { rule_name?: string } = data || {};
 
     const user = useMemo(() => extractData('user'), [])
 
@@ -327,11 +327,6 @@ const useSimulationController = (props: ISimulation) => {
             : _values?.payload || {};
         if (isReadOnly) {
 
-            if (!tenant_id) {
-                toast.error('Tenant ID is missing. Cannot run simulation.')
-                return
-            }
-
             const rule_config_id = data?.rule_config_id
             const id = rule_config_id?.toString().split('@')[0]
             const version = data?.version
@@ -404,7 +399,7 @@ const useSimulationController = (props: ISimulation) => {
                 setResult(null);
             });
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [selected, user?.claims, ruleOnly, endToEnd, toggleSimulationExecuted, updateMetadata, addSimulationLog, tenant_id])
+    }, [selected, user?.claims, ruleOnly, endToEnd, toggleSimulationExecuted, updateMetadata, addSimulationLog])
 
     const handleReport = () => {
         open('Test Report', <ViewReport data={data} />, null, { maxWidth: 'xl' })


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
This pull request updates the way destination and consumer identifiers are constructed in the simulation controller logic for the Rule Editor. The change removes the inclusion of the `tenant_id` from both identifiers, simplifying their format.

**Simulation controller identifier simplification:**

* Updated the construction of `destination` and `consumer` fields in the `body` object within `useSimulationController.tsx` to exclude the `tenant_id`, using only the `id` and `version` for both. (`frontend/src/pages/RuleEditor/Simulation/useSimulationController.tsx`)


## Why are we doing this?

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved simulation request routing by simplifying identifiers used for message delivery, enhancing reliability when executing simulations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->