### PR TITLE
ci: replace CODEOWNERS individual handles with team handles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Justus-at-Tazama @Sandy-at-Tazama @scott45
+* @tazama-lf/core-codeowners @tazama-lf/community-codeowners


### PR DESCRIPTION
Replace individual GitHub usernames in .github/CODEOWNERS with the correct team handles. The catch-all rule now uses the org team handles instead of personal accounts.