### PR TITLE
feat: Add RBAC implementation for simulation sandbox with two new roles

### DIFF
--- a/backend/src/decorators/auth.decorator.ts
+++ b/backend/src/decorators/auth.decorator.ts
@@ -33,6 +33,8 @@ export const TazamaClaims = {
   DEFAULT_ROLES_TAZAMA_CMS: 'default-roles-tazama-cms',
   OFFLINE_ACCESS: 'offline_access',
   UMA_AUTHORIZATION: 'uma_authorization',
+  DATA_ENGINEER_EDITOR: 'trs_data_engineer_editor',
+  DATA_ENGINEER_APPROVER: 'trs_data_engineer_approver',
 } as const;
 
 export const RequireEditorRole = (): MethodDecorator => RequireClaim(TazamaClaims.EDITOR);
@@ -40,3 +42,4 @@ export const RequireApproverRole = (): MethodDecorator => RequireClaim(TazamaCla
 export const RequirePublisherRole = (): MethodDecorator => RequireClaim(TazamaClaims.PUBLISHER);
 export const RequireAccountManagement = (): MethodDecorator =>
   RequireClaims(TazamaClaims.MANAGE_ACCOUNT, TazamaClaims.MANAGE_ACCOUNT_LINKS);
+

--- a/backend/src/guards/tazama-auth.guard.ts
+++ b/backend/src/guards/tazama-auth.guard.ts
@@ -57,7 +57,7 @@ export class TazamaAuthGuard implements CanActivate {
     const realmAccess = innerDecoded.realm_access as { roles?: string[] } | undefined;
     const realmRoles = realmAccess?.roles;
 
-    const supportedRoles = new Set(['editor', 'approver', 'publisher']);
+    const supportedRoles = new Set(['editor', 'approver', 'publisher', 'data_engineer_editor', 'data_engineer_approver']);
     const actorRole = realmRoles?.find((role: string) => supportedRoles.has(role.toLowerCase()));
     if (!actorRole) {
       throw new UnauthorizedException('No supported RBAC role found in token');

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -22,7 +22,7 @@ export class AuthService {
   }
 
   private validateUserToken(token: string, username: string): void {
-    const claimsToCheck = ['editor', 'approver', 'publisher'];
+    const claimsToCheck = ['editor', 'approver', 'publisher',  'trs_data_engineer_editor', 'trs_data_engineer_approver'];
     let claimResult;
     try {
       claimResult = validateTokenAndClaims(token, claimsToCheck);
@@ -32,9 +32,12 @@ export class AuthService {
       throw new UnauthorizedException('Token validation failed');
     }
 
-    const hasRequiredClaim = [claimResult.editor, claimResult.approver, claimResult.publisher].some((claim) => !!claim);
+    const hasRequiredClaim = claimsToCheck.some((claim) => !!claimResult[claim]);
     if (!hasRequiredClaim) {
-      this.loggerService.warn(`User ${username} does not have required claims (editor, approver, or publisher).`, AuthService.name);
+      this.loggerService.warn(
+        `User ${username} does not have required claims (editor, approver, publisher, trs_data_engineer_editor, or trs_data_engineer_approver).`,
+        AuthService.name,
+      );
       throw new UnauthorizedException('Invalid credentials');
     }
   }

--- a/backend/test/auth/auth.service.spec.ts
+++ b/backend/test/auth/auth.service.spec.ts
@@ -97,6 +97,8 @@ describe('AuthService', () => {
         'editor',
         'approver',
         'publisher',
+        'trs_data_engineer_editor',
+        'trs_data_engineer_approver',
       ]);
 
       expect(loggerService.log).toHaveBeenCalledWith(
@@ -121,7 +123,7 @@ describe('AuthService', () => {
       );
 
       expect(loggerService.warn).toHaveBeenCalledWith(
-        `User ${username} does not have required claims (editor, approver, or publisher).`,
+        `User ${username} does not have required claims (editor, approver, publisher, trs_data_engineer_editor, or trs_data_engineer_approver).`,
         'AuthService',
       );
     });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,24 +9,35 @@ import MainLayout from './layout/MainLayout';
 import { ROUTES } from './routes';
 import PrivateRoute from './routes/PrivateRoute';
 import ProtectedRoute from './routes/ProtectedRoute';
+import RoleRoute from './routes/RoleRoute';
 import theme from './utils/Theme';
 
 const themeMode = createTheme(theme());
 
 function App() {
 
-  const privateWithLayoutRoutes = useMemo(
-    () => ROUTES.filter(route => route.private === true && route.layout === true),
-    []
-  );
-
   const publicNoLayoutRoutes = useMemo(
     () => ROUTES.filter(route => route.private === false && route.layout === false),
     []
   );
 
-  const privateWithoutLayoutRoutes = useMemo(
-    () => ROUTES.filter(route => route.private === true && route.layout === false),
+  const trsWithLayoutRoutes = useMemo(
+    () => ROUTES.filter(route => route.private === true && route.layout === true && route.roleGroup === 'trs'),
+    []
+  );
+
+  const trsWithoutLayoutRoutes = useMemo(
+    () => ROUTES.filter(route => route.private === true && route.layout === false && route.roleGroup === 'trs'),
+    []
+  );
+
+  const dataEngineerWithLayoutRoutes = useMemo(
+    () => ROUTES.filter(route => route.private === true && route.layout === true && route.roleGroup === 'data-engineer'),
+    []
+  );
+
+  const unrestrictedPrivateRoutes = useMemo(
+    () => ROUTES.filter(route => route.private === true && route.roleGroup === null),
     []
   );
 
@@ -37,29 +48,33 @@ function App() {
           <Toaster position="top-right" reverseOrder={false} />
           <Routes>
             <Route element={<ProtectedRoute />}>
-              <Route >
-                {
-                  publicNoLayoutRoutes.map((item, index) => (
-                    <Route key={index} path={item.path} element={item.element} />
-                  ))
-                }
-              </Route>
+              {publicNoLayoutRoutes.map((item, index) => (
+                <Route key={index} path={item.path} element={item.element} />
+              ))}
             </Route>
             <Route element={<PrivateRoute />}>
-              <Route element={<MainLayout />}>
-                {
-                  privateWithLayoutRoutes.map((item, index) => (
+              <Route element={<RoleRoute group="trs" />}>
+                <Route element={<MainLayout />}>
+                  {trsWithLayoutRoutes.map((item, index) => (
                     <Route key={index} path={item.path} element={item.element} />
-                  ))
-                }
+                  ))}
+                </Route>
               </Route>
-              <Route>
-                {
-                  privateWithoutLayoutRoutes.map((item, index) => (
+              <Route element={<RoleRoute group="trs" />}>
+                {trsWithoutLayoutRoutes.map((item, index) => (
+                  <Route key={index} path={item.path} element={item.element} />
+                ))}
+              </Route>
+              <Route element={<RoleRoute group="data-engineer" />}>
+                <Route element={<MainLayout />}>
+                  {dataEngineerWithLayoutRoutes.map((item, index) => (
                     <Route key={index} path={item.path} element={item.element} />
-                  ))
-                }
+                  ))}
+                </Route>
               </Route>
+              {unrestrictedPrivateRoutes.map((item, index) => (
+                <Route key={index} path={item.path} element={item.element} />
+              ))}
             </Route>
           </Routes>
         </ModalProvider>

--- a/frontend/src/layout/Sidebar/index.tsx
+++ b/frontend/src/layout/Sidebar/index.tsx
@@ -1,23 +1,27 @@
-import HelpOutlineOutlinedIcon from '@mui/icons-material/HelpOutlineOutlined';
 import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined';
-import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
-import StorageRoundedIcon from '@mui/icons-material/StorageRounded';
+import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
 import { Box } from "@mui/material";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Text } from "../../components/Text";
 import * as S from './Sidebar.styles';
 import LogoutIcon from '@mui/icons-material/Logout';
-import { resetData } from '../../utils/Common/storage';
+import { extractData, resetData } from '../../utils/Common/storage';
+import { TRS_ROLES } from '../../utils/Constants/data';
 
-const menuItems: { icon: React.ReactElement, label: string, route: string, color: string }[] = [
-    { icon: <HomeOutlinedIcon />, label: "Rules Home", route: "home", color: "#8f57ee" },
-    { icon: <StorageRoundedIcon />, label: "Datasets", route: "datasets", color: "#2bc08f" },
-    { icon: <SettingsOutlinedIcon />, label: "Settings", route: "settings", color: "#f5a319" },
-    { icon: <HelpOutlineOutlinedIcon />, label: "Help", route: "help", color: "#8f57ee" },
+const sharedMenuItems: { icon: React.ReactElement, label: string, route: string, color: string }[] = [
+    { icon: <HomeOutlinedIcon />, label: "Home", route: "home", color: "#8f57ee" },
+];
+
+const trsMenuItems: { icon: React.ReactElement, label: string, route: string, color: string }[] = [
+    { icon: <ScienceOutlinedIcon />, label: "Sandbox", route: "sandbox", color: "#2bc08f" },
 ];
 
 const Sidebar = ({ expanded }: { expanded: boolean; }) => {
+    const user = extractData('user') || {};
+    const isTrs = TRS_ROLES.includes(user?.claims ?? '');
+    const menuItems = isTrs ? [...sharedMenuItems, ...trsMenuItems] : sharedMenuItems;
+
     const [activeIdx, setActiveIdx] = useState(0);
 
     const handleMenuClick = (idx: number) => {

--- a/frontend/src/layout/Sidebar/index.tsx
+++ b/frontend/src/layout/Sidebar/index.tsx
@@ -17,10 +17,14 @@ const trsMenuItems: { icon: React.ReactElement, label: string, route: string, co
     { icon: <ScienceOutlinedIcon />, label: "Sandbox", route: "sandbox", color: "#2bc08f" },
 ];
 
+const dataEngineerMenuItems: { icon: React.ReactElement, label: string, route: string, color: string }[] = [
+    { icon: <HomeOutlinedIcon />, label: "Masking Configuration", route: "masking-config", color: "#8f57ee" },
+];
+
 const Sidebar = ({ expanded }: { expanded: boolean; }) => {
     const user = extractData('user') || {};
     const isTrs = TRS_ROLES.includes(user?.claims ?? '');
-    const menuItems = isTrs ? [...sharedMenuItems, ...trsMenuItems] : sharedMenuItems;
+    const menuItems = isTrs ? [...sharedMenuItems, ...trsMenuItems] : dataEngineerMenuItems;
 
     const [activeIdx, setActiveIdx] = useState(0);
 

--- a/frontend/src/pages/Auth/Login/useLoginController.tsx
+++ b/frontend/src/pages/Auth/Login/useLoginController.tsx
@@ -6,6 +6,7 @@ import { insertData } from '../../../utils/Common/storage';
 import { useNavigate } from 'react-router-dom';
 import { decodeToken } from '../../../utils/Common/helpers';
 import { loginValidation } from '../../../validation/schemas/authSchema';
+import { DATA_ENGINEER_ROLES } from '../../../utils/Constants/data';
 
 const initial = {
     username: '',
@@ -29,7 +30,8 @@ const useLoginController = () => {
             insertData(data?.token, "access_token")
             const details = decodeToken(data?.token)
             insertData(details, 'user')
-            navigate("/home")
+            const target = DATA_ENGINEER_ROLES.includes(details?.claims ?? '') ? '/masking-config' : '/home'
+            navigate(target)
         }
     }, [isSuccess, data, navigate])
 

--- a/frontend/src/pages/MaskingConfig/index.tsx
+++ b/frontend/src/pages/MaskingConfig/index.tsx
@@ -1,0 +1,20 @@
+import { Box } from "@mui/material";
+import { Text } from "../../components/Text";
+import BoxWrapper from "../../components/Wrappers/BoxWrapper";
+
+const MaskingConfig = () => {
+    return (
+        <BoxWrapper>
+            <Box display="flex" flexDirection="column" gap={2}>
+                <Text weight="bold" color="black" size="header">
+                    Masking Configuration
+                </Text>
+                <Text color="text.ternary" size="body">
+                    Configure data masking rules and policies.
+                </Text>
+            </Box>
+        </BoxWrapper>
+    );
+};
+
+export default MaskingConfig;

--- a/frontend/src/routes/ProtectedRoute/index.tsx
+++ b/frontend/src/routes/ProtectedRoute/index.tsx
@@ -1,13 +1,15 @@
 import { Navigate, Outlet } from "react-router-dom";
 import { extractData } from "../../utils/Common/storage";
+import { DATA_ENGINEER_ROLES } from "../../utils/Constants/data";
 
 const ProtectedRoute = () => {
 
-    const isAuthenticated = () => {
-        return !!extractData("access_token")
-    }
+    const token = extractData("access_token")
+    if (!token) return <Outlet />
 
-    return isAuthenticated() ? <Navigate to="/home" /> : <Outlet />
+    const user = extractData("user")
+    const redirectTo = DATA_ENGINEER_ROLES.includes(user?.claims ?? '') ? '/masking-config' : '/home'
+    return <Navigate to={redirectTo} />
 
 };
 

--- a/frontend/src/routes/RoleRoute/index.tsx
+++ b/frontend/src/routes/RoleRoute/index.tsx
@@ -1,0 +1,25 @@
+import { Navigate, Outlet } from "react-router-dom";
+import { extractData } from "../../utils/Common/storage";
+import { DATA_ENGINEER_ROLES, TRS_ROLES } from "../../utils/Constants/data";
+
+interface RoleRouteProps {
+    group: 'trs' | 'data-engineer';
+}
+
+const RoleRoute = ({ group }: RoleRouteProps) => {
+    const user = extractData('user')
+    const role: string = user?.claims ?? ''
+
+    const allowed = group === 'data-engineer'
+        ? DATA_ENGINEER_ROLES.includes(role)
+        : TRS_ROLES.includes(role)
+
+    if (!allowed) {
+        const fallback = DATA_ENGINEER_ROLES.includes(role) ? '/masking-config' : '/home'
+        return <Navigate to={fallback} replace />
+    }
+
+    return <Outlet />
+};
+
+export default RoleRoute;

--- a/frontend/src/routes/RoleRoute/index.tsx
+++ b/frontend/src/routes/RoleRoute/index.tsx
@@ -14,6 +14,13 @@ const RoleRoute = ({ group }: RoleRouteProps) => {
         ? DATA_ENGINEER_ROLES.includes(role)
         : TRS_ROLES.includes(role)
 
+    const isKnownRole =
+        DATA_ENGINEER_ROLES.includes(role) || TRS_ROLES.includes(role)
+
+    if (!isKnownRole) {
+        return <Navigate to="/login" replace />
+    }
+
     if (!allowed) {
         const fallback = DATA_ENGINEER_ROLES.includes(role) ? '/masking-config' : '/home'
         return <Navigate to={fallback} replace />

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -8,84 +8,112 @@ const Login = lazy(() => import("../pages/Auth/Login"));
 const Home = lazy(() => import("../pages/Home"));
 const RuleEditor = lazy(() => import("../pages/RuleEditor"));
 const ComingSoon = lazy(() => import("../pages/ComingSoon"));
+const MaskingConfig = lazy(() => import("../pages/MaskingConfig"));
 
 export const ROUTES = [
     {
         path: "/components",
         element: <Components />,
         private: true,
-        layout: false
+        layout: false,
+        roleGroup: null,
     },
     {
         path: "/",
         element: <Navigate to="/login" replace />,
         private: false,
         layout: false,
+        roleGroup: null,
     },
     {
         path: "/login",
         element: <Login />,
         private: false,
-        layout: false
+        layout: false,
+        roleGroup: null,
     },
     {
         path: "/home",
         element: <Home />,
         private: true,
         layout: true,
+        roleGroup: 'trs' as const,
     },
     {
         path: "/editor",
         element: <RuleEditor />,
         private: true,
         layout: true,
+        roleGroup: 'trs' as const,
     },
     {
         path: "/editor/:id",
         element: <RuleEditor />,
         private: true,
         layout: true,
+        roleGroup: 'trs' as const,
     },
     {
         path: '/rule-builder/:id',
         element: <RuleBuilder />,
         private: true,
-        layout: false
+        layout: false,
+        roleGroup: 'trs' as const,
     },
     {
         path: '/rule-builder/view/:id',
         element: <RuleBuilder viewOnly />,
         private: true,
-        layout: false
+        layout: false,
+        roleGroup: 'trs' as const,
     },
     {
         path: '/test-case-generate/:ruleId',
         element: <TestCaseGenerate />,
         private: true,
-        layout: false
+        layout: false,
+        roleGroup: 'trs' as const,
     },
     {
         path: '/test-case-generate/view/:ruleId',
         element: <TestCaseGenerate viewOnly />,
         private: true,
-        layout: false
+        layout: false,
+        roleGroup: 'trs' as const,
     },
     {
         path: "/datasets",
         element: <ComingSoon />,
         private: true,
         layout: true,
+        roleGroup: 'trs' as const,
     },
     {
         path: "/settings",
         element: <ComingSoon />,
         private: true,
         layout: true,
+        roleGroup: 'trs' as const,
     },
     {
         path: "/help",
         element: <ComingSoon />,
         private: true,
         layout: true,
+        roleGroup: 'trs' as const,
+    },
+    {
+        path: "/sandbox",
+        element: <ComingSoon />,
+        private: true,
+        layout: true,
+        roleGroup: 'trs' as const,
+    },
+    {
+        path: "/masking-config",
+        element: <MaskingConfig />,
+        private: true,
+        layout: true,
+        roleGroup: 'data-engineer' as const,
     },
 ];

--- a/frontend/src/utils/Common/helpers.ts
+++ b/frontend/src/utils/Common/helpers.ts
@@ -179,7 +179,9 @@ export const toDropdown = (value?: string | null): DropdownOption | null =>
   value ? { label: value, value } : null;
 
 export const capitalize = (value: string) =>
-  value.charAt(0).toUpperCase() + value.slice(1);
+  value
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
 
 
 const decodeJwtPayload = (token: string): Record<string, unknown> | null => {

--- a/frontend/src/utils/Constants/data.ts
+++ b/frontend/src/utils/Constants/data.ts
@@ -244,8 +244,21 @@ export const Tabs = [
 export const claims = {
     editor: 'editor',
     approver: 'approver',
-    publisher: 'publisher'
+    publisher: 'publisher',
+    data_engineer_editor: 'data_engineer_editor',
+    data_engineer_approver: 'data_engineer_approver',
 }
+
+export const DATA_ENGINEER_ROLES: string[] = [
+    claims.data_engineer_editor,
+    claims.data_engineer_approver,
+]
+
+export const TRS_ROLES: string[] = [
+    claims.editor,
+    claims.approver,
+    claims.publisher,
+]
 
 export const RoleStatusMap: Record<string, string[]> = {
     editor: Object.values(Status),


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
This pull request introduces a new "data engineer" role group and implements role-based routing and access control for both backend and frontend. It adds support for `data_engineer_editor` and `data_engineer_approver` roles, updates authentication and authorization logic, and refactors the frontend to route users based on their roles, including a new Masking Configuration page for data engineers.

**Backend: Role and Claim Support**

- Added new claims `trs_data_engineer_editor` and `trs_data_engineer_approver` to `TazamaClaims`, and updated role/claim checks in the authentication guard and service to include these roles. [[1]](diffhunk://#diff-8dc00833cdc7ecf771f6d2e266ded09ff53bf2d90c1e3eff38be160416a2007fR36-R45) [[2]](diffhunk://#diff-241efef114dec203d4fbda9789c83b3331e0b55d224c7969614e7079535b3468L60-R60) [[3]](diffhunk://#diff-efb526d1eb72363a928158c9f2b98bf73e757c5610a4e10e00ed067d3075738cL25-R25) [[4]](diffhunk://#diff-efb526d1eb72363a928158c9f2b98bf73e757c5610a4e10e00ed067d3075738cL35-R40)
- Updated backend tests to cover new data engineer roles and adjusted warning messages accordingly. [[1]](diffhunk://#diff-5f42cbf518ad3fe411453542beb40424a544c5ca06efc75085fae99c12f2a7c5R100-R101) [[2]](diffhunk://#diff-5f42cbf518ad3fe411453542beb40424a544c5ca06efc75085fae99c12f2a7c5L124-R126)

**Frontend: Role-Based Routing and Navigation**

- Refactored route definitions in `ROUTES` to include a `roleGroup` property, and implemented a new `RoleRoute` component to restrict access to routes by role group. Updated `App.tsx` to use these new route guards and to separate routes for TRS and data engineer users. [[1]](diffhunk://#diff-76c525e44e2cbc13acdaecc89ba3d7137f124731e1308aa137a8de291300d3dcR11-R117) [[2]](diffhunk://#diff-9d047515c2cc6aef5b4280a42904c18c876c97c5b70c30c15120f3605d3b1c6eR1-R25) [[3]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR12-R40) [[4]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL40-R77)
- Added a new Masking Configuration page (`/masking-config`) for data engineer roles, and ensured data engineers are redirected to this page after login or when accessing protected routes. [[1]](diffhunk://#diff-1d42ab13bb7b2133c610865e59fea05ef8580982b9a8dbee3f25f7620ed82b11R1-R20) [[2]](diffhunk://#diff-95e6aaa857bedb3f5e7ec7b15ef835c6b7b224adc827d58e34539569c4a166f8R9) [[3]](diffhunk://#diff-95e6aaa857bedb3f5e7ec7b15ef835c6b7b224adc827d58e34539569c4a166f8L32-R34) [[4]](diffhunk://#diff-3d1b869b0a75dffdc7c490f81bd712804b95e4df6d7937df6daf7c15f385d0afR3-R12)

**Frontend: Navigation and Sidebar Updates**

- Updated the sidebar to show menu items based on user role, displaying the "Sandbox" option for TRS users and customizing the home route label.

**Shared Utilities and Constants**

- Added constants for TRS and data engineer roles, and updated the `capitalize` helper to improve label formatting for roles. [[1]](diffhunk://#diff-5fca44ee039741b839122f7fe0a2828c1ff677dbfb919fde2e4fd0b684109f71L247-R262) [[2]](diffhunk://#diff-c73cd57145d8885c0c2a5758beea6a6d8f6709c7d4be975fc2fbdd5690e9e00eL182-R184)

User Story Link:
https://github.com/frmscoe/paysys-pmo/issues/699

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Data Engineer Editor and Data Engineer Approver roles and a Masking Configuration page
  * Role-aware navigation, conditional sidebar menus, and post-login redirects based on role

* **Refactor**
  * Expanded authentication/authorization to recognize the new roles and updated route grouping to be role-scoped

* **Tests**
  * Updated authorization tests to cover the new role claims
<!-- end of auto-generated comment: release notes by coderabbit.ai -->