### PR TITLE
fix: use BuildKit secret mount for GH_TOKEN in backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+# SPDX-License-Identifier: Apache-2.0
 ARG BUILD_IMAGE=node:20-bullseye
 ARG RUN_IMAGE=gcr.io/distroless/nodejs20-debian11:nonroot
 
@@ -10,9 +12,8 @@ COPY ./src ./src
 COPY ./package*.json ./
 COPY ./tsconfig.json ./
 COPY .npmrc ./
-ARG GH_TOKEN
 
-RUN npm ci --ignore-scripts
+RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm ci --ignore-scripts
 RUN npm run build
 
 
@@ -22,8 +23,7 @@ LABEL stage=pre-prod
 
 COPY package*.json ./
 COPY .npmrc ./
-ARG GH_TOKEN
-RUN npm ci --ignore-scripts
+RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm ci --ignore-scripts
 
 FROM ${RUN_IMAGE} AS run-env
 USER nonroot


### PR DESCRIPTION
﻿## Problem

The `dockerhub-image-build-dual-rc.yml` workflow passes `GH_TOKEN` to the Docker build as a **secret** (via `--secret id=GH_TOKEN`), but the backend `Dockerfile` declared it as a build **arg** (`ARG GH_TOKEN`). The `ARG` directive receives an empty value when the token is passed as a secret, causing `npm ci --ignore-scripts` to fail authentication against the private GitHub npm registry.

## Fix

Replace the `ARG GH_TOKEN` declaration and bare `RUN npm ci` with the BuildKit secret mount pattern used consistently across all other service repos in the org:

```dockerfile
RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm ci --ignore-scripts
```

Also adds `# syntax=docker/dockerfile:1` as the first line to ensure BuildKit parser directives are recognised.

## References

- Workflow PR: https://github.com/tazama-lf/workflows/pull/77
- Pattern source: `event-director/Dockerfile` (canonical working example)