### PR TITLE
fix: variable type casting issue

### DIFF
--- a/frontend/src/hooks/RuleBuilder/useLocalVariables.ts
+++ b/frontend/src/hooks/RuleBuilder/useLocalVariables.ts
@@ -161,7 +161,31 @@ export const useLocalVariables = ({
           } else {
             // Resolve template variables in the value
             const resolvedValue = resolveTemplateVariables(varValue);
-            localVars[varName] = resolvedValue;
+            // Cast the stored value to the declared dataType so the variable tree
+            // shows the correct type label (number, boolean, array, object, string).
+            if (dataType === 'number') {
+              const num = Number(resolvedValue);
+              localVars[varName] = isNaN(num) ? resolvedValue : num;
+            } else if (dataType === 'boolean') {
+              localVars[varName] = resolvedValue === 'true' ? true : resolvedValue === 'false' ? false : resolvedValue;
+            } else if (dataType === 'array') {
+              try {
+                const parsed = JSON.parse(resolvedValue);
+                localVars[varName] = Array.isArray(parsed) ? parsed : [];
+              } catch {
+                localVars[varName] = [];
+              }
+            } else if (dataType === 'object') {
+              try {
+                const parsed = JSON.parse(resolvedValue);
+                localVars[varName] = (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) ? parsed : {};
+              } catch {
+                localVars[varName] = {};
+              }
+            } else {
+              // 'string' or 'any' — keep the resolved string value
+              localVars[varName] = resolvedValue;
+            }
           }
         }
       }

--- a/frontend/src/hooks/RuleBuilder/useLocalVariables.ts
+++ b/frontend/src/hooks/RuleBuilder/useLocalVariables.ts
@@ -167,7 +167,8 @@ export const useLocalVariables = ({
               const num = Number(resolvedValue);
               localVars[varName] = isNaN(num) ? resolvedValue : num;
             } else if (dataType === 'boolean') {
-              localVars[varName] = resolvedValue === 'true' ? true : resolvedValue === 'false' ? false : resolvedValue;
+              const normalized = resolvedValue.trim().toLowerCase();
+              localVars[varName] = normalized === 'true' || normalized === '1';
             } else if (dataType === 'array') {
               try {
                 const parsed = JSON.parse(resolvedValue);


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0
This pull request enhances the handling of local variable types in the `useLocalVariables` hook to ensure that variables are correctly cast to their declared data types. This improves the accuracy of type labels displayed in the variable tree, making the UI more reliable and user-friendly.

**Improvements to variable type casting:**

* Enhanced the logic in `useLocalVariables.ts` to cast variable values to their declared `dataType` (`number`, `boolean`, `array`, `object`, `string`, or `any`), including parsing and fallback behavior for invalid values. This ensures the variable tree displays the correct type labels and the stored values match the expected types.
## What did we change?

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variable type handling in the Rule Builder to properly convert and validate resolved values according to their declared data types. Numbers are coerced with fallback handling for invalid values, booleans validate specific string formats, and complex types like arrays and objects parse JSON with safe fallback defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->