### PR TITLE
feat: update the copyright provided by the tazama team

### DIFF
--- a/frontend/src/pages/Auth/Login/index.tsx
+++ b/frontend/src/pages/Auth/Login/index.tsx
@@ -1,4 +1,5 @@
 import { Box, CssBaseline } from '@mui/material';
+import { APACHE_LICENSE_URL } from '../../../utils/Constants';
 import Logo from '../../../assets/logo.png';
 import tazamaLogo from '../../../assets/tazamaLogo.svg';
 import treeImage from '../../../assets/treeImage.png';
@@ -79,8 +80,18 @@ const Login = () => {
                             <Button text="LOGIN" loading={values?.isLoading} type='primary' size='lg' Icon={LoginIcon} onClick={functions.handleSubmit} />
                         </S.FormWrapper>
 
-                        <S.FooterText variant="body2" color="text.black">
-                            &copy; {new Date().getFullYear()} Tazama. Powered by Paysys Labs.
+                        <S.FooterText variant="body2" color="text.black" align="center">
+                            &copy; {new Date().getFullYear()} LF Charities, Inc. and contributors to the Tazama project
+                            <br />
+                            Licensed under{' '}
+                            <a
+                                href={APACHE_LICENSE_URL}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                style={{ color: 'inherit' }}
+                            >
+                                Apache-2.0
+                            </a>
                         </S.FooterText>
                     </S.LoginCard>
                 </S.LeftSection>

--- a/frontend/src/utils/Constants/index.ts
+++ b/frontend/src/utils/Constants/index.ts
@@ -1,5 +1,7 @@
 export const NAV_HEIGHT = 60;
 
+export const APACHE_LICENSE_URL = 'https://github.com/tazama-lf/rule-studio/blob/main/LICENSE';
+
 export const serial_no_option = {
   label: "S. No",
   key: "id",


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
This pull request updates the login page footer to improve licensing and attribution information, and introduces a new constant for the Apache license URL. The most important changes are:

**Licensing and Attribution Updates:**

* The footer text in the login page (`Login/index.tsx`) now attributes the project to "LF Charities, Inc. and contributors to the Tazama project" and states the project is licensed under Apache-2.0, providing a direct link to the license.

**Codebase Improvements:**

* Added a new constant `APACHE_LICENSE_URL` in `Constants/index.ts` to store the link to the Apache 2.0 license, and updated the login page to use this constant. [[1]](diffhunk://#diff-5f0bd8bc72aeb17389faefb2d24a6b29a54c6b54d5d56bee70b90ad67410d0cbR3-R4) [[2]](diffhunk://#diff-6e0f58b73e4cbf4ced8faea7bd842481a526b9625ea84383de0c86b4c6040b86R2)

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated login page footer with copyright notice for LF Charities, Inc. and Tazama project contributors, including an Apache 2.0 license link.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tazama-lf/rule-studio/pull/75)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->