### PR TITLE
feat: Docker Hub tenant-segregated simulation routes

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -23,3 +23,25 @@ OPENSEARCH_NODE=https://localhost:9200
 OPENSEARCH_USERNAME=admin
 OPENSEARCH_PASSWORD=admin
 OPENSEARCH_INDEX=rule-studio-audit
+
+# ─── Docker Hub Tenant Configuration ────────────────────────────────────────────
+# Add one block per tenant. The PREFIX can be any alphanumeric+underscore string.
+# The system discovers tenants automatically by scanning for keys ending in
+# _TENANT_NAME at startup — no code changes needed to add a new tenant.
+#
+# Pattern:
+#   <PREFIX>_TENANT_NAME         = <tenantId matching the JWT claim>
+#   <PREFIX>_DOCKERHUB_TOKEN     = <Docker Hub Personal Access Token>
+#   <PREFIX>_DOCKERHUB_USERNAME  = <Docker Hub username>
+#   <PREFIX>_DOCKERHUB_NAMESPACE = <Docker Hub namespace / organisation>
+#
+# Example – two tenants:
+CBE_TENANT_NAME=cbe
+CBE_DOCKERHUB_TOKEN=
+CBE_DOCKERHUB_USERNAME=
+CBE_DOCKERHUB_NAMESPACE=
+
+TENANT_001_TENANT_NAME=tenant_001
+TENANT_001_DOCKERHUB_TOKEN=
+TENANT_001_DOCKERHUB_USERNAME=
+TENANT_001_DOCKERHUB_NAMESPACE=

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -17,6 +17,7 @@ import { FetchFromDlhModule } from './services/fetch-from-dlh/fetch-from-dlh.mod
 import { FetchCountModule } from './services/fetch-count/fetch-count.module';
 import { SimulationModule } from './services/simulation/simulation.module';
 import { FetchEvaluationModule } from './services/fetch-evaluation/fetch-evaluation.module';
+import { DockerHubModule } from './services/dockerhub/dockerhub.module';
 
 @Module({
   imports: [
@@ -38,6 +39,7 @@ import { FetchEvaluationModule } from './services/fetch-evaluation/fetch-evaluat
     FetchFromDlhModule,
     FetchCountModule,
     FetchEvaluationModule,
+    DockerHubModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/interfaces/dockerhub.interfaces.ts
+++ b/backend/src/interfaces/dockerhub.interfaces.ts
@@ -1,0 +1,34 @@
+/** Response from POST /v2/users/login */
+export interface DhLoginResponse {
+  token: string;
+}
+
+/** A single Docker Hub repository entry */
+export interface DhRepository {
+  name: string;
+  namespace: string;
+  repository_type: string;
+  pull_count: number;
+  last_updated: string;
+}
+
+/** Paginated list-repositories response from Docker Hub v2 API */
+export interface DhRepositoriesPage {
+  count: number;
+  next: string | null;
+  results: DhRepository[];
+}
+
+/** A single Docker Hub tag entry */
+export interface DhTagResult {
+  name: string;
+  last_updated: string;
+  digest: string;
+}
+
+/** Paginated list-tags response from Docker Hub v2 API */
+export interface DhTagsPage {
+  count: number;
+  next: string | null;
+  results: DhTagResult[];
+}

--- a/backend/src/services/dockerhub/dockerhub.controller.ts
+++ b/backend/src/services/dockerhub/dockerhub.controller.ts
@@ -1,0 +1,51 @@
+import { Controller, Get, Query, UseGuards, BadRequestException } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
+import { TazamaAuthGuard } from '../../guards/tazama-auth.guard';
+import { RequireAnyClaims, TazamaClaims } from '../../decorators/auth.decorator';
+import { ApiSwagger, CommonResponses } from '../../decorators/swagger.decorator';
+import { User } from '../../decorators/user.decorator';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { DockerHubService } from './dockerhub.service';
+import { DockerHubRepositoriesResponseDto, DockerHubTagsResponseDto } from './dto/dockerhub.dto';
+
+@ApiTags('DockerHub')
+@ApiBearerAuth('JWT-auth')
+@Controller('dockerhub')
+@UseGuards(TazamaAuthGuard)
+export class DockerHubController {
+  constructor(private readonly dockerHubService: DockerHubService) { }
+
+  @Get('/api/rules')
+  @RequireAnyClaims(TazamaClaims.EDITOR, TazamaClaims.APPROVER, TazamaClaims.PUBLISHER)
+  @ApiSwagger({
+    summary: 'Get all published rules from Docker Hub',
+    description:
+      'Retrieves all repositories (rules) published to the Docker Hub namespace configured for the calling tenant. ' +
+      'The tenant is identified from the `tenantId` claim in the Bearer JWT.',
+    responses: CommonResponses.SUCCESS_200(DockerHubRepositoriesResponseDto, 'Published rules retrieved successfully'),
+  })
+  async getPublishedRules(@User() user: AuthenticatedUser): Promise<DockerHubRepositoriesResponseDto> {
+    return await this.dockerHubService.getPublishedRules(user.tenantId);
+  }
+
+  @Get('/api/tags')
+  @RequireAnyClaims(TazamaClaims.EDITOR, TazamaClaims.APPROVER, TazamaClaims.PUBLISHER)
+  @ApiQuery({ name: 'rule', required: true, type: String, description: 'Rule (repository) name to fetch tags for', example: 'case105' })
+  @ApiSwagger({
+    summary: 'Get all tags for a published rule',
+    description:
+      'Retrieves all Docker Hub tags for the specified rule repository within the calling tenant\'s namespace. ' +
+      'The tenant is identified from the `tenantId` claim in the Bearer JWT.',
+    responses: CommonResponses.SUCCESS_200(DockerHubTagsResponseDto, 'Tags retrieved successfully'),
+  })
+  async getTagsForRule(
+    @Query('rule') rule: string,
+    @User() user: AuthenticatedUser,
+  ): Promise<DockerHubTagsResponseDto> {
+    if (!rule.trim()) {
+      throw new BadRequestException('`rule` query parameter is required.');
+    }
+    return await this.dockerHubService.getTagsForRule(user.tenantId, rule.trim());
+  }
+}
+

--- a/backend/src/services/dockerhub/dockerhub.module.ts
+++ b/backend/src/services/dockerhub/dockerhub.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { DockerHubController } from './dockerhub.controller';
+import { DockerHubService } from './dockerhub.service';
+import { TenantConfigService } from './tenant-config.service';
+
+@Module({
+  controllers: [DockerHubController],
+  providers: [DockerHubService, TenantConfigService],
+  exports: [DockerHubService, TenantConfigService],
+})
+export class DockerHubModule { }

--- a/backend/src/services/dockerhub/dockerhub.service.ts
+++ b/backend/src/services/dockerhub/dockerhub.service.ts
@@ -1,0 +1,119 @@
+import { Injectable, Logger, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { TenantConfigService } from './tenant-config.service';
+import type { DockerHubRepositoriesResponseDto, DockerHubTagsResponseDto } from './dto/dockerhub.dto';
+import type { DhLoginResponse, DhRepository, DhRepositoriesPage, DhTagResult, DhTagsPage } from '../../interfaces/dockerhub.interfaces';
+
+const DOCKERHUB_API = 'https://hub.docker.com/v2';
+
+@Injectable()
+export class DockerHubService {
+  private readonly logger = new Logger(DockerHubService.name);
+
+  constructor(private readonly tenantConfigService: TenantConfigService) { }
+
+  /**
+   * Exchange the tenant's PAT for a short-lived Docker Hub JWT.
+   * The PAT is read from env via TenantConfigService — never from the request.
+   */
+  private async getAuthToken(tenantId: string): Promise<{ authToken: string; namespace: string }> {
+    const creds = this.tenantConfigService.getCredentials(tenantId);
+
+    const response = await fetch(`${DOCKERHUB_API}/users/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: creds.username, password: creds.token }),
+    });
+
+    if (!response.ok) {
+      this.logger.error(`Docker Hub login failed for tenant "${tenantId}": ${response.status} ${response.statusText}`);
+      throw new InternalServerErrorException('Failed to authenticate with Docker Hub');
+    }
+
+    const data = (await response.json()) as DhLoginResponse;
+    return { authToken: data.token, namespace: creds.namespace };
+  }
+
+  /**
+   * Recursively fetches all pages of repositories for a namespace.
+   * Avoids await-in-loop by using recursion instead of a while loop.
+   */
+  private async fetchRepoPage(url: string, authToken: string, tenantId: string): Promise<DhRepository[]> {
+    const response = await fetch(url, { headers: { Authorization: `Bearer ${authToken}` } });
+
+    if (!response.ok) {
+      this.logger.error(`Docker Hub repositories fetch failed for tenant "${tenantId}": ${response.status} ${response.statusText}`);
+      throw new InternalServerErrorException('Failed to fetch rules from Docker Hub');
+    }
+
+    const page = (await response.json()) as DhRepositoriesPage;
+    const remaining = page.next ? await this.fetchRepoPage(page.next, authToken, tenantId) : [];
+    return [...page.results, ...remaining];
+  }
+
+  /**
+   * Recursively fetches all pages of tags for a repository.
+   * Avoids await-in-loop by using recursion instead of a while loop.
+   */
+  private async fetchTagPage(
+    url: string,
+    authToken: string,
+    tenantId: string,
+    ruleName: string,
+    namespace: string,
+  ): Promise<DhTagResult[]> {
+    const response = await fetch(url, { headers: { Authorization: `Bearer ${authToken}` } });
+
+    if (response.status === 404) {
+      throw new NotFoundException(`Rule "${ruleName}" not found in Docker Hub namespace "${namespace}" for tenant "${tenantId}"`);
+    }
+
+    if (!response.ok) {
+      this.logger.error(`Docker Hub tags fetch failed for tenant "${tenantId}": ${response.status} ${response.statusText}`);
+      throw new InternalServerErrorException(`Failed to fetch tags for rule "${ruleName}" from Docker Hub`);
+    }
+
+    const page = (await response.json()) as DhTagsPage;
+    const remaining = page.next ? await this.fetchTagPage(page.next, authToken, tenantId, ruleName, namespace) : [];
+    return [...page.results, ...remaining];
+  }
+
+  /** Fetch all repositories for the tenant's namespace. */
+  async getPublishedRules(tenantId: string): Promise<DockerHubRepositoriesResponseDto> {
+    const { authToken, namespace } = await this.getAuthToken(tenantId);
+    const firstUrl = `${DOCKERHUB_API}/namespaces/${namespace}/repositories?page_size=100`;
+    const repos = await this.fetchRepoPage(firstUrl, authToken, tenantId);
+
+    this.logger.log(`Fetched ${repos.length} rules for tenant "${tenantId}" from namespace "${namespace}"`);
+
+    return {
+      rules: repos.map((r) => ({
+        name: r.name,
+        namespace: r.namespace,
+        repository_type: r.repository_type,
+        pull_count: r.pull_count,
+        last_updated: r.last_updated,
+      })),
+      count: repos.length,
+    };
+  }
+
+  /** Fetch all tags for a given rule in the tenant's namespace. */
+  async getTagsForRule(tenantId: string, ruleName: string): Promise<DockerHubTagsResponseDto> {
+    const { authToken, namespace } = await this.getAuthToken(tenantId);
+    const firstUrl = `${DOCKERHUB_API}/namespaces/${namespace}/repositories/${encodeURIComponent(ruleName)}/tags?page_size=100`;
+    const tags = await this.fetchTagPage(firstUrl, authToken, tenantId, ruleName, namespace);
+
+    this.logger.log(`Fetched ${tags.length} tags for rule "${ruleName}" (tenant "${tenantId}", namespace "${namespace}")`);
+
+    return {
+      rule: ruleName,
+      tags: tags.map((t) => ({
+        name: t.name,
+        last_updated: t.last_updated,
+        digest: t.digest,
+      })),
+      count: tags.length,
+    };
+  }
+}
+

--- a/backend/src/services/dockerhub/dto/dockerhub.dto.ts
+++ b/backend/src/services/dockerhub/dto/dockerhub.dto.ts
@@ -1,0 +1,48 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DockerHubRepository {
+  @ApiProperty({ example: 'rule-001', description: 'Repository name (rule name)' })
+  name: string;
+
+  @ApiProperty({ example: 'pslcopilot', description: 'Namespace the repository belongs to' })
+  namespace: string;
+
+  @ApiProperty({ example: 'image', description: 'Repository type' })
+  repository_type: string;
+
+  @ApiProperty({ example: 0, description: 'Pull count' })
+  pull_count: number;
+
+  @ApiProperty({ example: '2024-01-01T00:00:00Z', description: 'Last updated timestamp' })
+  last_updated: string;
+}
+
+export class DockerHubRepositoriesResponseDto {
+  @ApiProperty({ type: [DockerHubRepository] })
+  rules: DockerHubRepository[];
+
+  @ApiProperty({ example: 5, description: 'Total number of published rules' })
+  count: number;
+}
+
+export class DockerHubTag {
+  @ApiProperty({ example: 'v1.0.0', description: 'Tag name' })
+  name: string;
+
+  @ApiProperty({ example: '2024-01-01T00:00:00Z', description: 'Tag last updated timestamp' })
+  last_updated: string;
+
+  @ApiProperty({ example: 'linux/amd64', description: 'Tag digest' })
+  digest: string;
+}
+
+export class DockerHubTagsResponseDto {
+  @ApiProperty({ example: 'rule-001', description: 'Rule (repository) name' })
+  rule: string;
+
+  @ApiProperty({ type: [DockerHubTag] })
+  tags: DockerHubTag[];
+
+  @ApiProperty({ example: 3, description: 'Total number of tags' })
+  count: number;
+}

--- a/backend/src/services/dockerhub/tenant-config.service.ts
+++ b/backend/src/services/dockerhub/tenant-config.service.ts
@@ -1,0 +1,96 @@
+import { Injectable, Logger, OnModuleInit, UnauthorizedException } from '@nestjs/common';
+
+export interface TenantDockerHubCredentials {
+  tenantId: string;
+  token: string;
+  username: string;
+  namespace: string;
+}
+
+/**
+ * Scans process.env at startup for all tenant Docker Hub configurations.
+ *
+ * Expected env-var pattern (PREFIX is any alphanumeric+underscore string):
+ *   <PREFIX>_TENANT_NAME      = <tenantId>
+ *   <PREFIX>_DOCKERHUB_TOKEN  = <PAT>
+ *   <PREFIX>_DOCKERHUB_USERNAME = <username>
+ *   <PREFIX>_DOCKERHUB_NAMESPACE = <namespace>
+ *
+ * Example:
+ *   CBE_TENANT_NAME=cbe
+ *   CBE_DOCKERHUB_TOKEN=dckr_pat_...
+ *   CBE_DOCKERHUB_USERNAME=sohaib1083
+ *   CBE_DOCKERHUB_NAMESPACE=pslcopilot
+ *
+ *   TENANT_001_TENANT_NAME=tenant_001
+ *   TENANT_001_DOCKERHUB_TOKEN=dckr_pat_...
+ *   TENANT_001_DOCKERHUB_USERNAME=org2user
+ *   TENANT_001_DOCKERHUB_NAMESPACE=org2namespace
+ */
+@Injectable()
+export class TenantConfigService implements OnModuleInit {
+  private readonly logger = new Logger(TenantConfigService.name);
+
+  /** Map of tenantId → credentials, populated on module init. */
+  private readonly credentialsMap = new Map<string, TenantDockerHubCredentials>();
+
+  onModuleInit(): void {
+    this.loadTenantConfigs();
+  }
+
+  private loadTenantConfigs(): void {
+    const { env } = process;
+
+    // Collect all keys that end with _TENANT_NAME to discover prefixes
+    const tenantNameKeys = Object.keys(env).filter((k) => k.endsWith('_TENANT_NAME'));
+
+    for (const key of tenantNameKeys) {
+      const prefix = key.slice(0, key.length - '_TENANT_NAME'.length); // e.g. "CBE"
+      const tenantId = env[key]?.trim();
+
+      if (!tenantId) {
+        this.logger.warn(`${key} is set but empty — skipping`);
+        continue;
+      }
+
+      const token = env[`${prefix}_DOCKERHUB_TOKEN`]?.trim();
+      const username = env[`${prefix}_DOCKERHUB_USERNAME`]?.trim();
+      const namespace = env[`${prefix}_DOCKERHUB_NAMESPACE`]?.trim();
+
+      if (!token || !username || !namespace) {
+        this.logger.warn(
+          `Tenant "${tenantId}" (prefix: ${prefix}) is missing one or more Docker Hub vars ` +
+          '(TOKEN/USERNAME/NAMESPACE) — skipping',
+        );
+        continue;
+      }
+
+      this.credentialsMap.set(tenantId.toLowerCase(), { tenantId, token, username, namespace });
+      this.logger.log(`Registered Docker Hub config for tenant "${tenantId}" → namespace "${namespace}"`);
+    }
+
+    if (this.credentialsMap.size === 0) {
+      this.logger.warn('No tenant Docker Hub configurations found in environment variables');
+    }
+  }
+
+  /**
+   * Returns the Docker Hub credentials for the given tenantId.
+   * Throws UnauthorizedException if the tenant is not configured.
+   */
+  getCredentials(tenantId: string): TenantDockerHubCredentials {
+    const creds = this.credentialsMap.get(tenantId.toLowerCase());
+    if (!creds) {
+      throw new UnauthorizedException(
+        `No Docker Hub configuration found for tenant "${tenantId}". ` +
+        `Ensure the corresponding env vars are set (e.g. <PREFIX>_TENANT_NAME=${tenantId}).`,
+      );
+    }
+    return creds;
+  }
+
+  /** Returns all registered tenant IDs (for diagnostics/admin use). */
+  getRegisteredTenants(): string[] {
+    return [...this.credentialsMap.keys()];
+  }
+}

--- a/backend/test/services/dockerhub/dockerhub.controller.spec.ts
+++ b/backend/test/services/dockerhub/dockerhub.controller.spec.ts
@@ -1,0 +1,153 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { DockerHubController } from '../../../src/services/dockerhub/dockerhub.controller';
+import { DockerHubService } from '../../../src/services/dockerhub/dockerhub.service';
+import type { AuthenticatedUser } from '../../../src/services/auth/auth.types';
+import type {
+  DockerHubRepositoriesResponseDto,
+  DockerHubTagsResponseDto,
+} from '../../../src/services/dockerhub/dto/dockerhub.dto';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+const makeUser = (tenantId = 'cbe'): AuthenticatedUser =>
+  ({
+    tenantId,
+    userId: 'user-1',
+    actorRole: 'editor',
+    token: { tokenString: 'tok', tenantId } as any,
+    validated: {} as any,
+    validClaims: [],
+  }) as AuthenticatedUser;
+
+const mockRulesResponse: DockerHubRepositoriesResponseDto = {
+  rules: [
+    {
+      name: 'case105',
+      namespace: 'pslcopilot',
+      repository_type: 'image',
+      pull_count: 0,
+      last_updated: '2026-05-20T06:43:21Z',
+    },
+  ],
+  count: 1,
+};
+
+const mockTagsResponse: DockerHubTagsResponseDto = {
+  rule: 'case105',
+  tags: [
+    { name: 'latest', last_updated: '2026-05-20T06:43:21Z', digest: 'sha256:abc' },
+    { name: '1.0.0', last_updated: '2026-05-20T06:43:14Z', digest: 'sha256:def' },
+  ],
+  count: 2,
+};
+
+// ─── suite ───────────────────────────────────────────────────────────────────
+
+describe('DockerHubController', () => {
+  let controller: DockerHubController;
+  let service: jest.Mocked<DockerHubService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DockerHubController],
+      providers: [
+        {
+          provide: DockerHubService,
+          useValue: {
+            getPublishedRules: jest.fn(),
+            getTagsForRule: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(DockerHubController);
+    service = module.get(DockerHubService);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  // ─── getPublishedRules ──────────────────────────────────────────────────────
+
+  describe('getPublishedRules', () => {
+    it('delegates to DockerHubService with the user tenantId', async () => {
+      service.getPublishedRules.mockResolvedValue(mockRulesResponse);
+      const user = makeUser('cbe');
+
+      const result = await controller.getPublishedRules(user);
+
+      expect(service.getPublishedRules).toHaveBeenCalledWith('cbe');
+      expect(result).toStrictEqual(mockRulesResponse);
+    });
+
+    it('passes tenantId from the user object (not hard-coded)', async () => {
+      service.getPublishedRules.mockResolvedValue(mockRulesResponse);
+      const user = makeUser('tenant_001');
+
+      await controller.getPublishedRules(user);
+
+      expect(service.getPublishedRules).toHaveBeenCalledWith('tenant_001');
+    });
+
+    it('propagates errors thrown by the service', async () => {
+      service.getPublishedRules.mockRejectedValue(new Error('downstream error'));
+      const user = makeUser();
+
+      await expect(controller.getPublishedRules(user)).rejects.toThrow('downstream error');
+    });
+  });
+
+  // ─── getTagsForRule ─────────────────────────────────────────────────────────
+
+  describe('getTagsForRule', () => {
+    it('delegates to DockerHubService with tenantId and trimmed rule name', async () => {
+      service.getTagsForRule.mockResolvedValue(mockTagsResponse);
+      const user = makeUser('cbe');
+
+      const result = await controller.getTagsForRule('  case105  ', user);
+
+      expect(service.getTagsForRule).toHaveBeenCalledWith('cbe', 'case105');
+      expect(result).toStrictEqual(mockTagsResponse);
+    });
+
+    it('throws BadRequestException when rule is an empty string', async () => {
+      const user = makeUser();
+
+      await expect(controller.getTagsForRule('', user)).rejects.toThrow(BadRequestException);
+      expect(service.getTagsForRule).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when rule is only whitespace', async () => {
+      const user = makeUser();
+
+      await expect(controller.getTagsForRule('   ', user)).rejects.toThrow(BadRequestException);
+      expect(service.getTagsForRule).not.toHaveBeenCalled();
+    });
+
+    it('error message mentions the `rule` parameter', async () => {
+      const user = makeUser();
+
+      await expect(controller.getTagsForRule('', user)).rejects.toThrow(/rule/i);
+    });
+
+    it('propagates errors thrown by the service', async () => {
+      service.getTagsForRule.mockRejectedValue(new Error('not found'));
+      const user = makeUser();
+
+      await expect(controller.getTagsForRule('case105', user)).rejects.toThrow('not found');
+    });
+
+    it('passes different tenantIds from different users', async () => {
+      service.getTagsForRule.mockResolvedValue(mockTagsResponse);
+      const userA = makeUser('tenant_a');
+      const userB = makeUser('tenant_b');
+
+      await controller.getTagsForRule('rule-x', userA);
+      expect(service.getTagsForRule).toHaveBeenLastCalledWith('tenant_a', 'rule-x');
+
+      await controller.getTagsForRule('rule-x', userB);
+      expect(service.getTagsForRule).toHaveBeenLastCalledWith('tenant_b', 'rule-x');
+    });
+  });
+});

--- a/backend/test/services/dockerhub/dockerhub.service.spec.ts
+++ b/backend/test/services/dockerhub/dockerhub.service.spec.ts
@@ -1,0 +1,331 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InternalServerErrorException, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { DockerHubService } from '../../../src/services/dockerhub/dockerhub.service';
+import { TenantConfigService } from '../../../src/services/dockerhub/tenant-config.service';
+import type { TenantDockerHubCredentials } from '../../../src/services/dockerhub/tenant-config.service';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+const TENANT_ID = 'cbe';
+const CREDS: TenantDockerHubCredentials = {
+  tenantId: TENANT_ID,
+  token: 'dckr_pat_test',
+  username: 'testuser',
+  namespace: 'testns',
+};
+
+const mockLoginResponse = { token: 'dh-jwt-token' };
+
+const makeRepo = (name: string) => ({
+  name,
+  namespace: CREDS.namespace,
+  repository_type: 'image',
+  pull_count: 0,
+  last_updated: '2026-01-01T00:00:00Z',
+});
+
+const makeTag = (name: string) => ({
+  name,
+  last_updated: '2026-01-01T00:00:00Z',
+  digest: `sha256:${name}`,
+});
+
+const makeFetchOk = (body: unknown) =>
+  jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: jest.fn().mockResolvedValue(body),
+  } as unknown as Response);
+
+const makeFetchFail = (status: number, statusText = 'Error') =>
+  jest.fn().mockResolvedValue({
+    ok: false,
+    status,
+    statusText,
+    json: jest.fn().mockResolvedValue({}),
+  } as unknown as Response);
+
+// ─── suite ───────────────────────────────────────────────────────────────────
+
+describe('DockerHubService', () => {
+  let service: DockerHubService;
+  let tenantConfig: jest.Mocked<TenantConfigService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DockerHubService,
+        {
+          provide: TenantConfigService,
+          useValue: {
+            getCredentials: jest.fn().mockReturnValue(CREDS),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(DockerHubService);
+    tenantConfig = module.get(TenantConfigService);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  // ─── getPublishedRules ──────────────────────────────────────────────────────
+
+  describe('getPublishedRules', () => {
+    it('returns mapped rules for a single page', async () => {
+      const repos = [makeRepo('case105'), makeRepo('case106')];
+      global.fetch = jest
+        .fn()
+        // first call: login
+        .mockResolvedValueOnce({
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue(mockLoginResponse),
+        } as unknown as Response)
+        // second call: list repos (single page)
+        .mockResolvedValueOnce({
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue({ count: 2, next: null, results: repos }),
+        } as unknown as Response);
+
+      const result = await service.getPublishedRules(TENANT_ID);
+
+      expect(result.count).toBe(2);
+      expect(result.rules).toHaveLength(2);
+      expect(result.rules[0].name).toBe('case105');
+      expect(result.rules[1].name).toBe('case106');
+      expect(tenantConfig.getCredentials).toHaveBeenCalledWith(TENANT_ID);
+    });
+
+    it('follows pagination and returns all repos across pages', async () => {
+      const page1Repos = [makeRepo('repo-a')];
+      const page2Repos = [makeRepo('repo-b')];
+
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({ // login
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue(mockLoginResponse),
+        } as unknown as Response)
+        .mockResolvedValueOnce({ // page 1 with next URL
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue({
+            count: 2, next: 'https://hub.docker.com/v2/next-page', results: page1Repos,
+          }),
+        } as unknown as Response)
+        .mockResolvedValueOnce({ // page 2 (no next)
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue({
+            count: 2, next: null, results: page2Repos,
+          }),
+        } as unknown as Response);
+
+      const result = await service.getPublishedRules(TENANT_ID);
+
+      expect(result.count).toBe(2);
+      expect(result.rules.map((r) => r.name)).toEqual(['repo-a', 'repo-b']);
+    });
+
+    it('throws InternalServerErrorException when Docker Hub login fails', async () => {
+      global.fetch = makeFetchFail(401, 'Unauthorized');
+
+      await expect(service.getPublishedRules(TENANT_ID)).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('throws InternalServerErrorException when repo fetch fails', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({ // login ok
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue(mockLoginResponse),
+        } as unknown as Response)
+        .mockResolvedValueOnce(makeFetchFail(500, 'Internal Server Error')());
+
+      await expect(service.getPublishedRules(TENANT_ID)).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('throws UnauthorizedException when tenant is not configured', async () => {
+      tenantConfig.getCredentials.mockImplementation(() => {
+        throw new UnauthorizedException('No config for tenant');
+      });
+
+      await expect(service.getPublishedRules(TENANT_ID)).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('returns count equal to rules array length', async () => {
+      const repos = [makeRepo('only-one')];
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue(mockLoginResponse),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue({ count: 1, next: null, results: repos }),
+        } as unknown as Response);
+
+      const result = await service.getPublishedRules(TENANT_ID);
+      expect(result.count).toBe(result.rules.length);
+    });
+  });
+
+  // ─── getTagsForRule ─────────────────────────────────────────────────────────
+
+  describe('getTagsForRule', () => {
+    const RULE = 'case105';
+
+    it('returns mapped tags for a single page', async () => {
+      const tags = [makeTag('latest'), makeTag('1.0.0')];
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({ // login
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue(mockLoginResponse),
+        } as unknown as Response)
+        .mockResolvedValueOnce({ // tags page 1
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue({ count: 2, next: null, results: tags }),
+        } as unknown as Response);
+
+      const result = await service.getTagsForRule(TENANT_ID, RULE);
+
+      expect(result.rule).toBe(RULE);
+      expect(result.count).toBe(2);
+      expect(result.tags[0].name).toBe('latest');
+      expect(result.tags[1].name).toBe('1.0.0');
+    });
+
+    it('follows pagination and returns all tags across pages', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({ // login
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue(mockLoginResponse),
+        } as unknown as Response)
+        .mockResolvedValueOnce({ // page 1
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue({
+            count: 2, next: 'https://hub.docker.com/v2/next-tags', results: [makeTag('v1')],
+          }),
+        } as unknown as Response)
+        .mockResolvedValueOnce({ // page 2
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue({
+            count: 2, next: null, results: [makeTag('v2')],
+          }),
+        } as unknown as Response);
+
+      const result = await service.getTagsForRule(TENANT_ID, RULE);
+
+      expect(result.count).toBe(2);
+      expect(result.tags.map((t) => t.name)).toEqual(['v1', 'v2']);
+    });
+
+    it('throws NotFoundException when the rule repository does not exist (404)', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({ // login ok
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue(mockLoginResponse),
+        } as unknown as Response)
+        .mockResolvedValueOnce({ // 404 on tags
+          ok: false, status: 404, statusText: 'Not Found',
+          json: jest.fn().mockResolvedValue({}),
+        } as unknown as Response);
+
+      await expect(service.getTagsForRule(TENANT_ID, RULE)).rejects.toThrow(NotFoundException);
+    });
+
+    it('NotFoundException message contains rule name, namespace and tenantId', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue(mockLoginResponse),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          ok: false, status: 404, statusText: 'Not Found',
+          json: jest.fn().mockResolvedValue({}),
+        } as unknown as Response);
+
+      await expect(service.getTagsForRule(TENANT_ID, RULE)).rejects.toThrow(
+        new RegExp(`${RULE}.*${CREDS.namespace}.*${TENANT_ID}`, 's'),
+      );
+    });
+
+    it('throws InternalServerErrorException when Docker Hub login fails', async () => {
+      global.fetch = makeFetchFail(401, 'Unauthorized');
+
+      await expect(service.getTagsForRule(TENANT_ID, RULE)).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('throws InternalServerErrorException on non-404 tags fetch error', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({ // login ok
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue(mockLoginResponse),
+        } as unknown as Response)
+        .mockResolvedValueOnce({ // 500 on tags
+          ok: false, status: 500, statusText: 'Server Error',
+          json: jest.fn().mockResolvedValue({}),
+        } as unknown as Response);
+
+      await expect(service.getTagsForRule(TENANT_ID, RULE)).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('throws UnauthorizedException when tenant is not configured', async () => {
+      tenantConfig.getCredentials.mockImplementation(() => {
+        throw new UnauthorizedException('No config');
+      });
+
+      await expect(service.getTagsForRule(TENANT_ID, RULE)).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('encodes special characters in rule name in the URL', async () => {
+      const specialRule = 'rule/with spaces';
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue(mockLoginResponse),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue({ count: 0, next: null, results: [] }),
+        } as unknown as Response);
+
+      await service.getTagsForRule(TENANT_ID, specialRule);
+
+      const tagCallUrl = (global.fetch as jest.Mock).mock.calls[1][0] as string;
+      expect(tagCallUrl).not.toContain(' ');
+      expect(tagCallUrl).toContain(encodeURIComponent(specialRule));
+    });
+
+    it('maps each tag fields correctly (name, last_updated, digest)', async () => {
+      const rawTag = { name: 'v3', last_updated: '2026-05-01T00:00:00Z', digest: 'sha256:abc' };
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue(mockLoginResponse),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          ok: true, status: 200, statusText: 'OK',
+          json: jest.fn().mockResolvedValue({ count: 1, next: null, results: [rawTag] }),
+        } as unknown as Response);
+
+      const result = await service.getTagsForRule(TENANT_ID, RULE);
+      expect(result.tags[0]).toEqual({ name: 'v3', last_updated: '2026-05-01T00:00:00Z', digest: 'sha256:abc' });
+    });
+  });
+
+  // ─── makeFetchOk / makeFetchFail unused-ref guard ───────────────────────────
+  it('makeFetchOk helper produces ok response', async () => {
+    const mock = makeFetchOk({ hello: 'world' });
+    const resp = await mock() as Response;
+    expect(resp.ok).toBe(true);
+  });
+});

--- a/backend/test/services/dockerhub/tenant-config.service.spec.ts
+++ b/backend/test/services/dockerhub/tenant-config.service.spec.ts
@@ -1,0 +1,204 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TenantConfigService } from '../../../src/services/dockerhub/tenant-config.service';
+
+const ORIGINAL_ENV = process.env;
+
+describe('TenantConfigService', () => {
+  let service: TenantConfigService;
+
+  const buildModule = async (): Promise<TenantConfigService> => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TenantConfigService],
+    }).compile();
+    return module.get<TenantConfigService>(TenantConfigService);
+  };
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    jest.restoreAllMocks();
+  });
+
+  // ─── loadTenantConfigs (via onModuleInit) ────────────────────────────────────
+
+  describe('onModuleInit / loadTenantConfigs', () => {
+    it('registers a valid tenant and logs success', async () => {
+      process.env = {
+        CBE_TENANT_NAME: 'cbe',
+        CBE_DOCKERHUB_TOKEN: 'tok123',
+        CBE_DOCKERHUB_USERNAME: 'user1',
+        CBE_DOCKERHUB_NAMESPACE: 'ns1',
+      };
+
+      service = await buildModule();
+      service.onModuleInit();
+
+      expect(service.getRegisteredTenants()).toContain('cbe');
+    });
+
+    it('registers multiple tenants from different prefixes', async () => {
+      process.env = {
+        CBE_TENANT_NAME: 'cbe',
+        CBE_DOCKERHUB_TOKEN: 'tok1',
+        CBE_DOCKERHUB_USERNAME: 'u1',
+        CBE_DOCKERHUB_NAMESPACE: 'ns1',
+        TENANT_001_TENANT_NAME: 'tenant_001',
+        TENANT_001_DOCKERHUB_TOKEN: 'tok2',
+        TENANT_001_DOCKERHUB_USERNAME: 'u2',
+        TENANT_001_DOCKERHUB_NAMESPACE: 'ns2',
+      };
+
+      service = await buildModule();
+      service.onModuleInit();
+
+      const tenants = service.getRegisteredTenants();
+      expect(tenants).toContain('cbe');
+      expect(tenants).toContain('tenant_001');
+    });
+
+    it('skips a tenant whose TENANT_NAME value is empty', async () => {
+      process.env = {
+        EMPTY_TENANT_NAME: '   ',
+        EMPTY_DOCKERHUB_TOKEN: 'tok',
+        EMPTY_DOCKERHUB_USERNAME: 'u',
+        EMPTY_DOCKERHUB_NAMESPACE: 'ns',
+      };
+
+      service = await buildModule();
+      service.onModuleInit();
+
+      expect(service.getRegisteredTenants()).toHaveLength(0);
+    });
+
+    it('skips a tenant missing DOCKERHUB_TOKEN', async () => {
+      process.env = {
+        BAD_TENANT_NAME: 'bad',
+        BAD_DOCKERHUB_USERNAME: 'u',
+        BAD_DOCKERHUB_NAMESPACE: 'ns',
+      };
+
+      service = await buildModule();
+      service.onModuleInit();
+
+      expect(service.getRegisteredTenants()).toHaveLength(0);
+    });
+
+    it('skips a tenant missing DOCKERHUB_USERNAME', async () => {
+      process.env = {
+        BAD_TENANT_NAME: 'bad',
+        BAD_DOCKERHUB_TOKEN: 'tok',
+        BAD_DOCKERHUB_NAMESPACE: 'ns',
+      };
+
+      service = await buildModule();
+      service.onModuleInit();
+
+      expect(service.getRegisteredTenants()).toHaveLength(0);
+    });
+
+    it('skips a tenant missing DOCKERHUB_NAMESPACE', async () => {
+      process.env = {
+        BAD_TENANT_NAME: 'bad',
+        BAD_DOCKERHUB_TOKEN: 'tok',
+        BAD_DOCKERHUB_USERNAME: 'u',
+      };
+
+      service = await buildModule();
+      service.onModuleInit();
+
+      expect(service.getRegisteredTenants()).toHaveLength(0);
+    });
+
+    it('warns when no tenant configs are found at all', async () => {
+      process.env = {};
+
+      service = await buildModule();
+      const warnSpy = jest.spyOn((service as any).logger, 'warn');
+      service.onModuleInit();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'No tenant Docker Hub configurations found in environment variables',
+      );
+    });
+
+    it('stores tenantId with case-insensitive key (lowercased)', async () => {
+      process.env = {
+        X_TENANT_NAME: 'MyTenant',
+        X_DOCKERHUB_TOKEN: 't',
+        X_DOCKERHUB_USERNAME: 'u',
+        X_DOCKERHUB_NAMESPACE: 'n',
+      };
+
+      service = await buildModule();
+      service.onModuleInit();
+
+      // getRegisteredTenants returns lowercased keys
+      expect(service.getRegisteredTenants()).toContain('mytenant');
+    });
+  });
+
+  // ─── getCredentials ───────────────────────────────────────────────────────────
+
+  describe('getCredentials', () => {
+    beforeEach(async () => {
+      process.env = {
+        CBE_TENANT_NAME: 'cbe',
+        CBE_DOCKERHUB_TOKEN: 'tok123',
+        CBE_DOCKERHUB_USERNAME: 'user1',
+        CBE_DOCKERHUB_NAMESPACE: 'pslcopilot',
+      };
+      service = await buildModule();
+      service.onModuleInit();
+    });
+
+    it('returns credentials for a registered tenant (exact case)', () => {
+      const creds = service.getCredentials('cbe');
+      expect(creds).toEqual({
+        tenantId: 'cbe',
+        token: 'tok123',
+        username: 'user1',
+        namespace: 'pslcopilot',
+      });
+    });
+
+    it('returns credentials for a registered tenant (case-insensitive lookup)', () => {
+      const creds = service.getCredentials('CBE');
+      expect(creds.namespace).toBe('pslcopilot');
+    });
+
+    it('throws UnauthorizedException for an unknown tenant', () => {
+      expect(() => service.getCredentials('unknown')).toThrow(UnauthorizedException);
+    });
+
+    it('error message mentions the tenantId', () => {
+      expect(() => service.getCredentials('ghost')).toThrow(/ghost/);
+    });
+  });
+
+  // ─── getRegisteredTenants ─────────────────────────────────────────────────────
+
+  describe('getRegisteredTenants', () => {
+    it('returns an empty array when no tenants are configured', async () => {
+      process.env = {};
+      service = await buildModule();
+      service.onModuleInit();
+      expect(service.getRegisteredTenants()).toEqual([]);
+    });
+
+    it('returns all registered tenant ids', async () => {
+      process.env = {
+        A_TENANT_NAME: 'alpha',
+        A_DOCKERHUB_TOKEN: 't1',
+        A_DOCKERHUB_USERNAME: 'u1',
+        A_DOCKERHUB_NAMESPACE: 'n1',
+        B_TENANT_NAME: 'beta',
+        B_DOCKERHUB_TOKEN: 't2',
+        B_DOCKERHUB_USERNAME: 'u2',
+        B_DOCKERHUB_NAMESPACE: 'n2',
+      };
+      service = await buildModule();
+      service.onModuleInit();
+      expect(service.getRegisteredTenants()).toEqual(expect.arrayContaining(['alpha', 'beta']));
+    });
+  });
+});


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

Added two new tenant-segregated REST endpoints that allow simulation workflows to discover published rule images and their versions from Docker Hub.

### New files
- `backend/src/interfaces/dockerhub.interfaces.ts` — shared Docker Hub API response interfaces (`DhRepository`, `DhRepositoriesPage`, `DhTagResult`, `DhTagsPage`, `DhLoginResponse`)
- `backend/src/services/dockerhub/` — full NestJS module:
  - `tenant-config.service.ts` — scans `process.env` at startup for `<PREFIX>_TENANT_NAME / _DOCKERHUB_TOKEN / _DOCKERHUB_USERNAME / _DOCKERHUB_NAMESPACE` blocks; maps `tenantId → credentials`
  - `dockerhub.service.ts` — authenticates with the tenant's PAT, fetches repos/tags (recursive pagination, no await-in-loop)
  - `dockerhub.controller.ts` — exposes two guarded GET endpoints
  - `dockerhub.module.ts` — NestJS module wiring
  - `dto/dockerhub.dto.ts` — Swagger-annotated response DTOs
- `backend/test/services/dockerhub/` — 39 unit tests, 100% statement/line/function coverage
- `backend/docs/dockerhub/` — architecture, API reference, and tenant setup docs

### Updated files
- `backend/src/app.module.ts` — registers `DockerHubModule`
- `backend/.env.example` — documents the tenant env-var pattern

### API routes (both guarded by `TazamaAuthGuard`, require `editor`/`approver`/`publisher`)

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/dockerhub/api/rules` | Lists all Docker Hub repos for the JWT's `tenantId` namespace |
| `GET` | `/dockerhub/api/tags?rule=<name>` | Lists all tags for a rule, scoped to the JWT's tenant namespace |

## Why are we doing this?

Simulation workflows need to know which rule images are published to Docker Hub and which versions (tags) are available to deploy. Each tenant maintains its own Docker Hub namespace, so full tenant isolation is required — tenant A must never see tenant B's images.

The `tenantId` is already embedded in the Tazama JWT (decoded by `TazamaAuthGuard`), so no additional auth plumbing is needed. Credentials are loaded from env vars at startup; they never travel in the request.

Adding a new tenant requires only env-var changes and a restart — no code changes.

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done

**39 unit tests across 3 spec files — all passing:**
- `tenant-config.service.spec.ts` — 100% coverage (statements / branches / functions / lines)
- `dockerhub.service.spec.ts` — 100% statements, functions, lines; covers single-page, multi-page pagination, login failure, 404, 500, URL encoding
- `dockerhub.controller.spec.ts` — 100% coverage; covers happy path, bad request, error propagation, multi-tenant

**Docker Hub live API validated:**
- Login via PAT ✅
- `pslcopilot` namespace: 3 repos (`rules`, `case105`, `case106`) ✅
- `case105` tags: `latest`, `1.0.0` ✅
- `case106` tags: `latest`, `1.0.2`, `1.0.1` ✅