### PR TITLE
feat: create simulation module

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -90,8 +90,8 @@
   },
   "lint-staged": {
     "**/*.{js,ts}": [
-      "npm run lint -- --fix",
-      "npm run format"
+      "eslint --fix",
+      "prettier --write"
     ]
   },
   "main": "index.js",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -17,6 +17,7 @@ import { FetchFromDlhModule } from './services/fetch-from-dlh/fetch-from-dlh.mod
 import { FetchCountModule } from './services/fetch-count/fetch-count.module';
 import { SimulationModule } from './services/simulation/simulation.module';
 import { FetchEvaluationModule } from './services/fetch-evaluation/fetch-evaluation.module';
+import { SimulationStudioModule } from './services/simulation-studio/simulation-studio.module';
 
 @Module({
   imports: [
@@ -38,8 +39,9 @@ import { FetchEvaluationModule } from './services/fetch-evaluation/fetch-evaluat
     FetchFromDlhModule,
     FetchCountModule,
     FetchEvaluationModule,
+    SimulationStudioModule,
   ],
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule { }
+export class AppModule {}

--- a/backend/src/constants/constant.ts
+++ b/backend/src/constants/constant.ts
@@ -62,3 +62,7 @@ export const STAGE_SIMULATION_ITEMS = '/v1/dlh/stage';
 // Evaluations
 export const GET_ALL_EVALUATIONS = '/v1/admin/reports/evaluations';
 export const FETCH_COUNT_DLH = '/v1/admin/dlh/fetch/count';
+
+// Simulation Studio
+export const SIMULATION_STUDIO_BASE_URL = '/v1/admin/trs/simulation-studio';
+export const SIMULATION_SUITES = `${SIMULATION_STUDIO_BASE_URL}/suites`;

--- a/backend/src/services/admin-service-client.ts
+++ b/backend/src/services/admin-service-client.ts
@@ -46,6 +46,7 @@ import {
   SIMULATION_CREATE,
   SIMULATION_STATS,
   SIMULATION_RESULTS,
+  SIMULATION_SUITES,
   SIMULATION_ITEMS,
   EXCLUDED_TYPES,
   STAGE_SIMULATION_ITEMS,
@@ -53,7 +54,14 @@ import {
   FETCH_COUNT_DLH,
 } from '../constants/constant';
 import type { MaskingFiltersDto, MaskingListResponseDto, UpdateMaskDto } from './masking/dto/masking.dto';
-import type { SimulationListResponseDto, CreateSimulationDto, CreateSimulationResponseDto, SimulationStatsDto, SimulationResultsResponseDto, ExcludedTypeProps } from './simulation/dto/simulation.dto';
+import type {
+  SimulationListResponseDto,
+  CreateSimulationDto,
+  CreateSimulationResponseDto,
+  SimulationStatsDto,
+  SimulationResultsResponseDto,
+  ExcludedTypeProps,
+} from './simulation/dto/simulation.dto';
 import { ResponseQueryNodeDto } from './nodes/dto/responseNode.dto';
 import { RuleRequest } from '../services/parse-extract/dto/message.dto';
 import { SimulationLogsDto } from './simulation-logs/dto';
@@ -62,6 +70,8 @@ import { CreateMaskDto } from './masking/dto/mask.dto';
 import { EvaluationRow } from './fetch-evaluation/dto/fetch-evaluation.dto';
 import { TransactionTypeDto } from './config/dto/config.dto';
 import { DlhCountDataDto, DlhCountResponse } from './fetch-from-dlh/dto/fetch-from-dlh.dto';
+import { PatchSimulationSuitesDto, SimulationSuitesDto, SimulationSuitesListDto, SimulationSuitesQueryDto } from './simulation-studio/dto';
+import type { ISimulationSuiteCreatePayload } from './simulation-studio/interface/simulation-studio.interface';
 
 export interface SimulationMessage {
   messageId: string;
@@ -237,7 +247,7 @@ export class AdminServiceClient {
     const response = await this.executeHttpRequest<{
       data: Array<Record<string, unknown>>;
       meta: { total: number; limit: number; offset: number };
-    }>('GET', NETWORK_MAP_LIST, token, undefined, { 'filters[active]': 'true', limit: '1' });
+    }>('GET', NETWORK_MAP_LIST, token, undefined, { 'filters[active]': 'true', 'limit': '1' });
 
     if (response.data.length === 0) {
       throw new HttpException('No active network map found', HttpStatus.NOT_FOUND);
@@ -423,27 +433,22 @@ export class AdminServiceClient {
   }
 
   async getSimulationStats(sim: string, iterationNo: string, token: string): Promise<SimulationStatsDto> {
-    return await this.executeHttpRequest<SimulationStatsDto>(
-      'GET',
-      SIMULATION_STATS,
-      token,
-      undefined,
-      { sim, iteration_no: iterationNo },
-    );
+    return await this.executeHttpRequest<SimulationStatsDto>('GET', SIMULATION_STATS, token, undefined, { sim, iteration_no: iterationNo });
   }
 
-  async getSimulationResults(sim: string, iterationNo: string, limit: number, offset: number, token: string, filters: { msg_id?: string; msg_type?: string; outcome?: string } = {}): Promise<SimulationResultsResponseDto> {
+  async getSimulationResults(
+    sim: string,
+    iterationNo: string,
+    limit: number,
+    offset: number,
+    token: string,
+    filters: { msg_id?: string; msg_type?: string; outcome?: string } = {},
+  ): Promise<SimulationResultsResponseDto> {
     const params: Record<string, string> = { sim, iteration_no: iterationNo, limit: String(limit), offset: String(offset) };
     if (filters.msg_id) params.msg_id = filters.msg_id;
     if (filters.msg_type) params.msg_type = filters.msg_type;
     if (filters.outcome) params.outcome = filters.outcome;
-    return await this.executeHttpRequest<SimulationResultsResponseDto>(
-      'GET',
-      SIMULATION_RESULTS,
-      token,
-      undefined,
-      params,
-    );
+    return await this.executeHttpRequest<SimulationResultsResponseDto>('GET', SIMULATION_RESULTS, token, undefined, params);
   }
 
   async stageSimulationItems(items: Array<Record<string, unknown>>, token: string): Promise<{ tableName: string | null }> {
@@ -460,13 +465,10 @@ export class AdminServiceClient {
   async fetchActiveMaskingConfigs(
     tuples: Array<{ tenant_id: string; txtp: string; txtp_version: string }>,
     token: string,
-  ): Promise<Array<{ tenant_id: string; txtp: string; txtp_version: string, endpoint_path: string }>> {
-    const response = await this.executeHttpRequest<{ masks: Array<{ tenant_id: string; txtp: string; txtp_version: string, endpoint_path: string }> }>(
-      'POST',
-      MASKING_ACTIVE_CONFIGS,
-      token,
-      tuples,
-    );
+  ): Promise<Array<{ tenant_id: string; txtp: string; txtp_version: string; endpoint_path: string }>> {
+    const response = await this.executeHttpRequest<{
+      masks: Array<{ tenant_id: string; txtp: string; txtp_version: string; endpoint_path: string }>;
+    }>('POST', MASKING_ACTIVE_CONFIGS, token, tuples);
     return response.masks;
   }
   async getAllEvaluations(token: string): Promise<{ message: string; data: EvaluationRow[] }> {
@@ -481,19 +483,62 @@ export class AdminServiceClient {
     return await this.executeHttpRequest<{ message: string }>('DELETE', '/v1/dlh/truncate-evaluations', token);
   }
 
-  async saveRecordInTrsSimulation(simulationData: { simulationId: string | undefined; totalRecord: number; recordProcessed: number; simStatus: string; tenantId: string }, token: string): Promise<{ message: string }> {
+  async saveRecordInTrsSimulation(
+    simulationData: { simulationId: string | undefined; totalRecord: number; recordProcessed: number; simStatus: string; tenantId: string },
+    token: string,
+  ): Promise<{ message: string }> {
     return await this.executeHttpRequest<{ message: string }>('POST', '/v1/admin/trs-simulation/save', token, simulationData);
   }
 
-  async getSimulationItems(token: string, tableName: string): Promise<Array<{ payload: Record<string, unknown>; endpointPath: string | null; credttm: string | null; tenantId: string | null; msgid: string | null }>> {
-    const response = await this.executeHttpRequest<{ items: Array<{ payload: Record<string, unknown>; endpointPath: string | null; credttm: string | null; tenantId: string | null; msgid: string | null }> }>(
-      'GET',
-      SIMULATION_ITEMS,
-      token,
-      undefined,
-      { tableName },
-    );
+  async getSimulationItems(
+    token: string,
+    tableName: string,
+  ): Promise<
+    Array<{
+      payload: Record<string, unknown>;
+      endpointPath: string | null;
+      credttm: string | null;
+      tenantId: string | null;
+      msgid: string | null;
+    }>
+  > {
+    const response = await this.executeHttpRequest<{
+      items: Array<{
+        payload: Record<string, unknown>;
+        endpointPath: string | null;
+        credttm: string | null;
+        tenantId: string | null;
+        msgid: string | null;
+      }>;
+    }>('GET', SIMULATION_ITEMS, token, undefined, { tableName });
     return response.items;
   }
 
+  // Endpoints for Simulation Studio
+
+  async getSimulationSuites(token: string, query: SimulationSuitesQueryDto = {}): Promise<SimulationSuitesListDto> {
+    const params: Record<string, string> = {};
+    if (query.search) params.search = query.search;
+    if (query.status) params.status = query.status;
+    if (query.rule_name) params.rule_name = query.rule_name;
+    if (query.txtp) params.txtp = query.txtp;
+    if (query.updated_from) params.updated_from = query.updated_from;
+    if (query.updated_to) params.updated_to = query.updated_to;
+    if (query.offset !== undefined) params.offset = String(query.offset);
+    if (query.limit !== undefined) params.limit = String(query.limit);
+
+    return await this.executeHttpRequest<SimulationSuitesListDto>('GET', SIMULATION_SUITES, token, undefined, params);
+  }
+
+  async getSimulationSuiteById(token: string, id: number): Promise<SimulationSuitesDto> {
+    return await this.executeHttpRequest<SimulationSuitesDto>('GET', `${SIMULATION_SUITES}/${id}`, token);
+  }
+
+  async createSimulationSuite(token: string, suite: ISimulationSuiteCreatePayload): Promise<SimulationSuitesDto> {
+    return await this.executeHttpRequest<SimulationSuitesDto>('POST', SIMULATION_SUITES, token, suite);
+  }
+
+  async patchSimulationSuite(token: string, id: number, payload: PatchSimulationSuitesDto): Promise<SimulationSuitesDto> {
+    return await this.executeHttpRequest<SimulationSuitesDto>('PATCH', `${SIMULATION_SUITES}/${id}`, token, payload);
+  }
 }

--- a/backend/src/services/admin-service-client.ts
+++ b/backend/src/services/admin-service-client.ts
@@ -70,7 +70,13 @@ import { CreateMaskDto } from './masking/dto/mask.dto';
 import { EvaluationRow } from './fetch-evaluation/dto/fetch-evaluation.dto';
 import { TransactionTypeDto } from './config/dto/config.dto';
 import { DlhCountDataDto, DlhCountResponse } from './fetch-from-dlh/dto/fetch-from-dlh.dto';
-import { PatchSimulationSuitesDto, SimulationSuitesDto, SimulationSuitesListDto, SimulationSuitesQueryDto } from './simulation-studio/dto';
+import {
+  PatchSimulationSuitesDto,
+  SimulationSuiteResponseDto,
+  SimulationSuitesDto,
+  SimulationSuitesListDto,
+  SimulationSuitesQueryDto,
+} from './simulation-studio/dto';
 import type { ISimulationSuiteCreatePayload } from './simulation-studio/interface/simulation-studio.interface';
 
 export interface SimulationMessage {
@@ -530,15 +536,15 @@ export class AdminServiceClient {
     return await this.executeHttpRequest<SimulationSuitesListDto>('GET', SIMULATION_SUITES, token, undefined, params);
   }
 
-  async getSimulationSuiteById(token: string, id: number): Promise<SimulationSuitesDto> {
-    return await this.executeHttpRequest<SimulationSuitesDto>('GET', `${SIMULATION_SUITES}/${id}`, token);
+  async getSimulationSuiteById(token: string, id: number): Promise<SimulationSuiteResponseDto> {
+    return await this.executeHttpRequest<SimulationSuiteResponseDto>('GET', `${SIMULATION_SUITES}/${id}`, token);
   }
 
   async createSimulationSuite(token: string, suite: ISimulationSuiteCreatePayload): Promise<SimulationSuitesDto> {
     return await this.executeHttpRequest<SimulationSuitesDto>('POST', SIMULATION_SUITES, token, suite);
   }
 
-  async patchSimulationSuite(token: string, id: number, payload: PatchSimulationSuitesDto): Promise<SimulationSuitesDto> {
-    return await this.executeHttpRequest<SimulationSuitesDto>('PATCH', `${SIMULATION_SUITES}/${id}`, token, payload);
+  async patchSimulationSuite(token: string, id: number, payload: PatchSimulationSuitesDto): Promise<SimulationSuiteResponseDto> {
+    return await this.executeHttpRequest<SimulationSuiteResponseDto>('PATCH', `${SIMULATION_SUITES}/${id}`, token, payload);
   }
 }

--- a/backend/src/services/simulation-studio/dto/index.ts
+++ b/backend/src/services/simulation-studio/dto/index.ts
@@ -97,6 +97,12 @@ export class SimulationSuitesDto {
 }
 
 export class SimulationSuitesListDto {
+  @ApiProperty({ description: 'Request status flag', example: true })
+  success: boolean;
+
+  @ApiProperty({ description: 'Response message', example: 'Simulation suites retrieved successfully' })
+  message: string;
+
   @ApiProperty({ type: [SimulationSuitesDto] })
   suites: SimulationSuitesDto[];
 
@@ -104,21 +110,18 @@ export class SimulationSuitesListDto {
   @Type(() => Number)
   @IsInt()
   @Min(0)
-  total: number;
+  total?: number;
+}
 
-  @ApiProperty({ description: 'Limit used for current query', required: false, example: 10 })
-  @Type(() => Number)
-  @IsOptional()
-  @IsInt()
-  @Min(0)
-  limit?: number;
+export class SimulationSuiteResponseDto {
+  @ApiProperty({ description: 'Request status flag', example: true })
+  success: boolean;
 
-  @ApiProperty({ description: 'Offset used for current query', required: false, example: 0 })
-  @Type(() => Number)
-  @IsOptional()
-  @IsInt()
-  @Min(0)
-  offset?: number;
+  @ApiProperty({ description: 'Response message', example: 'Simulation suite updated successfully' })
+  message: string;
+
+  @ApiProperty({ type: SimulationSuitesDto })
+  suite: SimulationSuitesDto;
 }
 
 export class RequestSimulationSuitesDto {

--- a/backend/src/services/simulation-studio/dto/index.ts
+++ b/backend/src/services/simulation-studio/dto/index.ts
@@ -1,0 +1,353 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsDateString, IsObject, IsEnum, IsOptional, IsInt, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { SimulationSuiteType, SimulationSuiteStatus } from 'src/utils/enums/simulation.enum';
+
+export class SimulationSuitesDto {
+  @ApiProperty({ description: 'Primary key', example: '101' })
+  @IsString()
+  id: string;
+
+  @ApiProperty({ description: 'Tenant identifier', example: 'tenant_001' })
+  @IsString()
+  tenant_id: string;
+
+  @ApiProperty({ description: 'Suite name', example: 'High Value Txns - Q3' })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({ description: 'Suite description', example: 'Quarterly high value transfer suite', required: false })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ description: 'Simulation type', enum: SimulationSuiteType, example: SimulationSuiteType.SINGLE_RULE })
+  @IsEnum(SimulationSuiteType)
+  simulation_type: SimulationSuiteType;
+
+  @ApiProperty({ description: 'Suite status', enum: SimulationSuiteStatus, example: SimulationSuiteStatus.DRAFT })
+  @IsEnum(SimulationSuiteStatus)
+  status: SimulationSuiteStatus;
+
+  @ApiProperty({ description: 'Rule repository identifier', required: false, example: 'repo-a' })
+  @IsOptional()
+  @IsString()
+  rule_repo?: string;
+
+  @ApiProperty({ description: 'Associated rule name', required: false, example: 'Rule 001' })
+  @IsOptional()
+  @IsString()
+  rule_name?: string;
+
+  @ApiProperty({ description: 'Associated rule version', required: false, example: 'v1.3.0' })
+  @IsOptional()
+  @IsString()
+  rule_version?: string;
+
+  @ApiProperty({ description: 'Primary transaction type (TXTP)', required: false, example: 'pacs.008' })
+  @IsOptional()
+  @IsString()
+  primary_txtp?: string;
+
+  @ApiProperty({ description: 'Primary transaction type version', required: false, example: '001.08' })
+  @IsOptional()
+  @IsString()
+  primary_txtp_version?: string;
+
+  @ApiProperty({ description: 'Source suite id when cloned', required: false, example: 88 })
+  @Type(() => Number)
+  @IsOptional()
+  @IsInt()
+  clone_source_suite_id?: number;
+
+  @ApiProperty({ description: 'Iteration count', example: 3 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  iteration_count: number;
+
+  @ApiProperty({ description: 'Run count', example: 2 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  run_count: number;
+
+  @ApiProperty({ description: 'Timestamp of last run', required: false, example: '2026-05-25T10:30:00.000Z' })
+  @IsOptional()
+  @IsDateString()
+  last_run_at?: string;
+
+  @ApiProperty({ description: 'Wizard progress payload', example: {} })
+  @IsObject()
+  wizard_progress: Record<string, unknown>;
+
+  @ApiProperty({ description: 'Additional metadata payload', example: {} })
+  @IsObject()
+  metadata: Record<string, unknown>;
+
+  @ApiProperty({ description: 'Creator user id/name', example: 'john.doe' })
+  @IsString()
+  created_by: string;
+
+  @ApiProperty({ description: 'Creator email', required: false, example: 'john.doe@acme.com' })
+  @IsOptional()
+  @IsString()
+  created_by_email?: string;
+}
+
+export class SimulationSuitesListDto {
+  @ApiProperty({ type: [SimulationSuitesDto] })
+  suites: SimulationSuitesDto[];
+
+  @ApiProperty({ description: 'Total number of matching suites', example: 25 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  total: number;
+
+  @ApiProperty({ description: 'Limit used for current query', required: false, example: 10 })
+  @Type(() => Number)
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  limit?: number;
+
+  @ApiProperty({ description: 'Offset used for current query', required: false, example: 0 })
+  @Type(() => Number)
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  offset?: number;
+}
+
+export class RequestSimulationSuitesDto {
+  @ApiProperty({ description: 'Suite name', example: 'Velocity Edge Cases' })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({ description: 'Suite description', required: false, example: 'Edge scenario set for velocity checks' })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ description: 'Simulation type', enum: SimulationSuiteType, required: false, default: SimulationSuiteType.SINGLE_RULE })
+  @IsOptional()
+  @IsEnum(SimulationSuiteType)
+  simulation_type?: SimulationSuiteType;
+
+  @ApiProperty({ description: 'Initial status', enum: SimulationSuiteStatus, required: false, default: SimulationSuiteStatus.DRAFT })
+  @IsOptional()
+  @IsEnum(SimulationSuiteStatus)
+  status?: SimulationSuiteStatus;
+
+  @ApiProperty({ description: 'Rule repository identifier', required: false, example: 'repo-b' })
+  @IsOptional()
+  @IsString()
+  rule_repo?: string;
+
+  @ApiProperty({ description: 'Associated rule name', required: false, example: 'Rule 002' })
+  @IsOptional()
+  @IsString()
+  rule_name?: string;
+
+  @ApiProperty({ description: 'Associated rule alias from UI payload', required: false, example: 'Rule 002' })
+  @IsOptional()
+  @IsString()
+  associated_rule?: string;
+
+  @ApiProperty({ description: 'Associated rule version', required: false, example: 'v2.1.0' })
+  @IsOptional()
+  @IsString()
+  rule_version?: string;
+
+  @ApiProperty({ description: 'Primary transaction type (TXTP)', required: false, example: 'pacs.002' })
+  @IsOptional()
+  @IsString()
+  primary_txtp?: string;
+
+  @ApiProperty({ description: 'TXTP alias from UI payload', required: false, example: 'pacs.002' })
+  @IsOptional()
+  @IsString()
+  txtp?: string;
+
+  @ApiProperty({ description: 'Primary transaction type version', required: false, example: '001.03' })
+  @IsOptional()
+  @IsString()
+  primary_txtp_version?: string;
+
+  @ApiProperty({ description: 'TXTP version alias from UI payload', required: false, example: '001.03' })
+  @IsOptional()
+  @IsString()
+  txtp_version?: string;
+
+  @ApiProperty({ description: 'Generic version alias from UI payload', required: false, example: '001.03' })
+  @IsOptional()
+  @IsString()
+  version?: string;
+
+  @ApiProperty({ description: 'Clone source suite ID', required: false, example: 101 })
+  @Type(() => Number)
+  @IsOptional()
+  @IsInt()
+  clone_source_suite_id?: number;
+
+  @ApiProperty({ description: 'Wizard progress payload', required: false, example: {} })
+  @IsOptional()
+  @IsObject()
+  wizard_progress?: Record<string, unknown>;
+
+  @ApiProperty({ description: 'Additional metadata payload', required: false, example: {} })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}
+
+export class PatchSimulationSuitesDto {
+  @ApiProperty({ description: 'Suite name', required: false, example: 'High Value Txns - Q4' })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiProperty({ description: 'Suite description', required: false, example: 'Updated suite description' })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ description: 'Simulation type', enum: SimulationSuiteType, required: false })
+  @IsOptional()
+  @IsEnum(SimulationSuiteType)
+  simulation_type?: SimulationSuiteType;
+
+  @ApiProperty({ description: 'Suite status', enum: SimulationSuiteStatus, required: false })
+  @IsOptional()
+  @IsEnum(SimulationSuiteStatus)
+  status?: SimulationSuiteStatus;
+
+  @ApiProperty({ description: 'Rule repository identifier', required: false })
+  @IsOptional()
+  @IsString()
+  rule_repo?: string;
+
+  @ApiProperty({ description: 'Associated rule name', required: false })
+  @IsOptional()
+  @IsString()
+  rule_name?: string;
+
+  @ApiProperty({ description: 'Associated rule alias from UI payload', required: false })
+  @IsOptional()
+  @IsString()
+  associated_rule?: string;
+
+  @ApiProperty({ description: 'Associated rule version', required: false })
+  @IsOptional()
+  @IsString()
+  rule_version?: string;
+
+  @ApiProperty({ description: 'Primary transaction type (TXTP)', required: false })
+  @IsOptional()
+  @IsString()
+  primary_txtp?: string;
+
+  @ApiProperty({ description: 'TXTP alias from UI payload', required: false })
+  @IsOptional()
+  @IsString()
+  txtp?: string;
+
+  @ApiProperty({ description: 'Primary transaction type version', required: false })
+  @IsOptional()
+  @IsString()
+  primary_txtp_version?: string;
+
+  @ApiProperty({ description: 'TXTP version alias from UI payload', required: false })
+  @IsOptional()
+  @IsString()
+  txtp_version?: string;
+
+  @ApiProperty({ description: 'Generic version alias from UI payload', required: false })
+  @IsOptional()
+  @IsString()
+  version?: string;
+
+  @ApiProperty({ description: 'Clone source suite ID', required: false })
+  @Type(() => Number)
+  @IsOptional()
+  @IsInt()
+  clone_source_suite_id?: number;
+
+  @ApiProperty({ description: 'Iteration count', required: false, example: 4 })
+  @Type(() => Number)
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  iteration_count?: number;
+
+  @ApiProperty({ description: 'Run count', required: false, example: 3 })
+  @Type(() => Number)
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  run_count?: number;
+
+  @ApiProperty({ description: 'Timestamp of last run', required: false, example: '2026-05-25T10:30:00.000Z' })
+  @IsOptional()
+  @IsDateString()
+  last_run_at?: string;
+
+  @ApiProperty({ description: 'Wizard progress payload', required: false, example: {} })
+  @IsOptional()
+  @IsObject()
+  wizard_progress?: Record<string, unknown>;
+
+  @ApiProperty({ description: 'Additional metadata payload', required: false, example: {} })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}
+
+export class SimulationSuitesQueryDto {
+  @ApiProperty({ description: 'Search by suite name (case-insensitive contains)', required: false, example: 'velocity' })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiProperty({ description: 'Filter by status', required: false, enum: SimulationSuiteStatus, example: SimulationSuiteStatus.DRAFT })
+  @IsOptional()
+  @IsEnum(SimulationSuiteStatus)
+  status?: SimulationSuiteStatus;
+
+  @ApiProperty({ description: 'Filter by associated rule name', required: false, example: 'Rule 002' })
+  @IsOptional()
+  @IsString()
+  rule_name?: string;
+
+  @ApiProperty({ description: 'Filter by transaction type (TXTP)', required: false, example: 'pacs.008' })
+  @IsOptional()
+  @IsString()
+  txtp?: string;
+
+  @ApiProperty({ description: 'Filter by updated date from (inclusive)', required: false, example: '2026-05-01' })
+  @IsOptional()
+  @IsString()
+  updated_from?: string;
+
+  @ApiProperty({ description: 'Filter by updated date to (inclusive)', required: false, example: '2026-05-31' })
+  @IsOptional()
+  @IsString()
+  updated_to?: string;
+
+  @ApiProperty({ description: 'Offset (0-based)', required: false, example: 0 })
+  @Type(() => Number)
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  offset?: number;
+
+  @ApiProperty({ description: 'Limit', required: false, example: 20 })
+  @Type(() => Number)
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  limit?: number;
+}

--- a/backend/src/services/simulation-studio/interface/common.types.ts
+++ b/backend/src/services/simulation-studio/interface/common.types.ts
@@ -1,0 +1,16 @@
+export type SuiteStatus = 'DRAFT' | 'RUNNING' | 'COMPLETED' | 'FAILED' | 'ARCHIVED';
+export type RunStatus = 'ENV_PROVISIONING' | 'RUNNING' | 'COMPLETED' | 'FAILED' | 'TIMED_OUT' | 'CANCELLED';
+export type RunPhase =
+  | 'ENV_PROVISIONING'
+  | 'NETWORK_CREATE'
+  | 'BASE_CONTAINERS_START'
+  | 'ODS_INIT'
+  | 'APP_CONTAINERS_START'
+  | 'TRANSACTION_LOOP'
+  | 'CLEANUP'
+  | 'COMPLETED'
+  | 'FAILED';
+export type ResultBand = 'good' | 'neutral' | 'bad' | 'error';
+export type ContextFieldStrategy = 'keep_sample' | 'static' | 'range' | 'generated' | 'null' | 'skip';
+export type TriggerFieldOverride = 'static' | 'range' | 'generated' | 'remove' | 'null';
+export type EnrichmentFieldStrategy = 'static' | 'range' | 'generated' | 'null' | 'copy';

--- a/backend/src/services/simulation-studio/interface/simulation-studio.interface.ts
+++ b/backend/src/services/simulation-studio/interface/simulation-studio.interface.ts
@@ -1,0 +1,14 @@
+import type { PatchSimulationSuitesDto, RequestSimulationSuitesDto, SimulationSuitesQueryDto, SimulationSuitesDto } from '../dto';
+
+export interface ISimulationSuitesListResponse {
+  suites: SimulationSuitesDto[];
+  total: number;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ISimulationSuiteCreatePayload extends RequestSimulationSuitesDto {}
+
+export type ISimulationSuitePatchPayload = PatchSimulationSuitesDto;
+
+export type ISimulationSuitesQuery = SimulationSuitesQueryDto;

--- a/backend/src/services/simulation-studio/simulation-studio.controller.ts
+++ b/backend/src/services/simulation-studio/simulation-studio.controller.ts
@@ -10,6 +10,7 @@ import { Audit } from 'src/decorators/audit.decorator';
 import {
   PatchSimulationSuitesDto,
   RequestSimulationSuitesDto,
+  SimulationSuiteResponseDto,
   SimulationSuitesDto,
   SimulationSuitesListDto,
   SimulationSuitesQueryDto,
@@ -23,7 +24,7 @@ export class SimulationStudioController {
   constructor(private readonly simulationStudioService: SimulationStudioService) {}
 
   @Get('suites')
-  @RequireAnyClaims(TazamaClaims.EDITOR, TazamaClaims.APPROVER, TazamaClaims.PUBLISHER)
+  @RequireAnyClaims(TazamaClaims.EDITOR, TazamaClaims.APPROVER)
   @ApiQuery({ name: 'search', required: false, type: String, description: 'Search by suite name (contains, case-insensitive)' })
   @ApiQuery({ name: 'status', required: false, type: String, description: 'Filter by suite status' })
   @ApiQuery({ name: 'rule_name', required: false, type: String, description: 'Filter by associated rule name' })
@@ -45,17 +46,20 @@ export class SimulationStudioController {
   }
 
   @Get('suites/:id')
-  @RequireAnyClaims(TazamaClaims.EDITOR, TazamaClaims.APPROVER, TazamaClaims.PUBLISHER)
+  @RequireAnyClaims(TazamaClaims.EDITOR, TazamaClaims.APPROVER)
   @ApiParam({ name: 'id', description: 'Simulation suite id', example: 1 })
   @ApiSwagger({
     summary: 'Get simulation suite by id',
     description: 'Retrieves a simulation suite by its numeric identifier',
     responses: mergeResponses(
-      CommonResponses.SUCCESS_200(SimulationSuitesDto, 'Simulation suite retrieved successfully'),
+      CommonResponses.SUCCESS_200(SimulationSuiteResponseDto, 'Simulation suite retrieved successfully'),
       CommonResponses.NOT_FOUND_404('Simulation suite not found'),
     ),
   })
-  async getSimulationSuiteById(@Param('id', ParseIntPipe) id: number, @User() user: AuthenticatedUser): Promise<SimulationSuitesDto> {
+  async getSimulationSuiteById(
+    @Param('id', ParseIntPipe) id: number,
+    @User() user: AuthenticatedUser,
+  ): Promise<SimulationSuiteResponseDto> {
     return await this.simulationStudioService.getSimulationSuiteById(user.token.tokenString, id);
   }
 
@@ -87,7 +91,7 @@ export class SimulationStudioController {
     summary: 'Patch simulation suite',
     description: 'Updates selected fields of an existing simulation suite',
     responses: mergeResponses(
-      CommonResponses.SUCCESS_200(SimulationSuitesDto, 'Simulation suite updated successfully'),
+      CommonResponses.SUCCESS_200(SimulationSuiteResponseDto, 'Simulation suite updated successfully'),
       CommonResponses.NOT_FOUND_404('Simulation suite not found'),
     ),
   })
@@ -95,7 +99,7 @@ export class SimulationStudioController {
     @Param('id', ParseIntPipe) id: number,
     @Body() payload: PatchSimulationSuitesDto,
     @User() user: AuthenticatedUser,
-  ): Promise<SimulationSuitesDto> {
+  ): Promise<SimulationSuiteResponseDto> {
     return await this.simulationStudioService.patchSimulationSuite(user.token.tokenString, id, payload);
   }
 }

--- a/backend/src/services/simulation-studio/simulation-studio.controller.ts
+++ b/backend/src/services/simulation-studio/simulation-studio.controller.ts
@@ -1,0 +1,101 @@
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiBody, ApiParam, ApiQuery } from '@nestjs/swagger';
+import { RequireAnyClaims, TazamaClaims } from 'src/decorators/auth.decorator';
+import { ApiSwagger, mergeResponses, CommonResponses } from 'src/decorators/swagger.decorator';
+import { TazamaAuthGuard } from 'src/guards/tazama-auth.guard';
+import { SimulationStudioService } from './simulation-studio.service';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { User } from 'src/decorators/user.decorator';
+import { Audit } from 'src/decorators/audit.decorator';
+import {
+  PatchSimulationSuitesDto,
+  RequestSimulationSuitesDto,
+  SimulationSuitesDto,
+  SimulationSuitesListDto,
+  SimulationSuitesQueryDto,
+} from './dto';
+
+@ApiTags('simulation-studio')
+@ApiBearerAuth('JWT-auth')
+@Controller('simulation-studio')
+@UseGuards(TazamaAuthGuard)
+export class SimulationStudioController {
+  constructor(private readonly simulationStudioService: SimulationStudioService) {}
+
+  @Get('suites')
+  @RequireAnyClaims(TazamaClaims.EDITOR, TazamaClaims.APPROVER, TazamaClaims.PUBLISHER)
+  @ApiQuery({ name: 'search', required: false, type: String, description: 'Search by suite name (contains, case-insensitive)' })
+  @ApiQuery({ name: 'status', required: false, type: String, description: 'Filter by suite status' })
+  @ApiQuery({ name: 'rule_name', required: false, type: String, description: 'Filter by associated rule name' })
+  @ApiQuery({ name: 'txtp', required: false, type: String, description: 'Filter by transaction type (TXTP)' })
+  @ApiQuery({ name: 'updated_from', required: false, type: String, description: 'Filter by updated date from (inclusive)' })
+  @ApiQuery({ name: 'updated_to', required: false, type: String, description: 'Filter by updated date to (inclusive)' })
+  @ApiQuery({ name: 'offset', required: false, type: Number, description: 'Page offset (0-based)' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Page size' })
+  @ApiSwagger({
+    summary: 'Get simulation suites',
+    description: 'Retrieves simulation suites with optional filters for suite name, status, and rule',
+    responses: mergeResponses(
+      CommonResponses.SUCCESS_200(SimulationSuitesListDto, 'Simulation suites retrieved successfully'),
+      CommonResponses.NOT_FOUND_404('Simulation suites not found'),
+    ),
+  })
+  async getSimulationSuites(@User() user: AuthenticatedUser, @Query() query: SimulationSuitesQueryDto): Promise<SimulationSuitesListDto> {
+    return await this.simulationStudioService.getSimulationSuites(user.token.tokenString, query);
+  }
+
+  @Get('suites/:id')
+  @RequireAnyClaims(TazamaClaims.EDITOR, TazamaClaims.APPROVER, TazamaClaims.PUBLISHER)
+  @ApiParam({ name: 'id', description: 'Simulation suite id', example: 1 })
+  @ApiSwagger({
+    summary: 'Get simulation suite by id',
+    description: 'Retrieves a simulation suite by its numeric identifier',
+    responses: mergeResponses(
+      CommonResponses.SUCCESS_200(SimulationSuitesDto, 'Simulation suite retrieved successfully'),
+      CommonResponses.NOT_FOUND_404('Simulation suite not found'),
+    ),
+  })
+  async getSimulationSuiteById(@Param('id', ParseIntPipe) id: number, @User() user: AuthenticatedUser): Promise<SimulationSuitesDto> {
+    return await this.simulationStudioService.getSimulationSuiteById(user.token.tokenString, id);
+  }
+
+  @Post('suites')
+  @RequireAnyClaims(TazamaClaims.EDITOR, TazamaClaims.APPROVER)
+  @Audit()
+  @ApiBody({
+    type: RequestSimulationSuitesDto,
+    description: 'Simulation suite payload to create',
+  })
+  @ApiSwagger({
+    summary: 'Create simulation suite',
+    description: 'Creates a new simulation suite',
+    responses: mergeResponses(CommonResponses.CREATED_201(SimulationSuitesDto, 'Simulation suite created successfully')),
+  })
+  async createSimulationSuites(@Body() suites: RequestSimulationSuitesDto, @User() user: AuthenticatedUser): Promise<SimulationSuitesDto> {
+    return await this.simulationStudioService.createSimulationSuites(user.token.tokenString, suites);
+  }
+
+  @Patch('suites/:id')
+  @RequireAnyClaims(TazamaClaims.EDITOR, TazamaClaims.APPROVER)
+  @Audit()
+  @ApiParam({ name: 'id', description: 'Simulation suite id', example: 1 })
+  @ApiBody({
+    type: PatchSimulationSuitesDto,
+    description: 'Partial simulation suite payload to update',
+  })
+  @ApiSwagger({
+    summary: 'Patch simulation suite',
+    description: 'Updates selected fields of an existing simulation suite',
+    responses: mergeResponses(
+      CommonResponses.SUCCESS_200(SimulationSuitesDto, 'Simulation suite updated successfully'),
+      CommonResponses.NOT_FOUND_404('Simulation suite not found'),
+    ),
+  })
+  async patchSimulationSuite(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() payload: PatchSimulationSuitesDto,
+    @User() user: AuthenticatedUser,
+  ): Promise<SimulationSuitesDto> {
+    return await this.simulationStudioService.patchSimulationSuite(user.token.tokenString, id, payload);
+  }
+}

--- a/backend/src/services/simulation-studio/simulation-studio.module.ts
+++ b/backend/src/services/simulation-studio/simulation-studio.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { AdminServiceClient } from '../admin-service-client';
+import { SimulationStudioController } from './simulation-studio.controller';
+import { SimulationStudioService } from './simulation-studio.service';
+
+@Module({
+  imports: [HttpModule],
+  controllers: [SimulationStudioController],
+  providers: [SimulationStudioService, AdminServiceClient],
+  exports: [SimulationStudioService],
+})
+export class SimulationStudioModule {}

--- a/backend/src/services/simulation-studio/simulation-studio.service.ts
+++ b/backend/src/services/simulation-studio/simulation-studio.service.ts
@@ -1,0 +1,97 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { AdminServiceClient } from '../admin-service-client';
+import {
+  PatchSimulationSuitesDto,
+  RequestSimulationSuitesDto,
+  SimulationSuitesDto,
+  SimulationSuitesListDto,
+  SimulationSuitesQueryDto,
+} from './dto';
+import type { ISimulationSuiteCreatePayload } from './interface/simulation-studio.interface';
+
+@Injectable()
+export class SimulationStudioService {
+  private readonly logger = new Logger(SimulationStudioService.name);
+
+  constructor(private readonly adminServiceClient: AdminServiceClient) {}
+
+  /**
+   * Fetches simulation suites with optional filters for suite name, status, and associated rule name.
+   * Supports pagination through offset and limit parameters.
+   * @param token - Authentication token for API access
+   * @param query - Query parameters for filtering and pagination
+   * @returns A list of simulation suites matching the query criteria along with pagination info
+   */
+  async getSimulationSuites(token: string, query: SimulationSuitesQueryDto): Promise<SimulationSuitesListDto> {
+    try {
+      const response = await this.adminServiceClient.getSimulationSuites(token, query);
+      this.logger.log('Successfully fetched simulation suites');
+      return response;
+    } catch (err) {
+      const error = err as Error;
+      this.logger.error('Error fetching simulation suites', error.stack);
+      throw error;
+    }
+  }
+
+  async getSimulationSuiteById(token: string, id: number): Promise<SimulationSuitesDto> {
+    try {
+      return await this.adminServiceClient.getSimulationSuiteById(token, id);
+    } catch (err) {
+      const error = err as Error;
+      this.logger.error(`Error fetching simulation suite by id: ${id}`, error.stack);
+      throw error;
+    }
+  }
+
+  async createSimulationSuites(token: string, suites: RequestSimulationSuitesDto): Promise<SimulationSuitesDto> {
+    try {
+      const payload: ISimulationSuiteCreatePayload = {
+        name: suites.name,
+        description: suites.description,
+        simulation_type: suites.simulation_type,
+        status: suites.status,
+        rule_repo: suites.rule_repo,
+        rule_version: suites.rule_version,
+        clone_source_suite_id: suites.clone_source_suite_id,
+        metadata: suites.metadata,
+        rule_name: suites.rule_name ?? suites.associated_rule,
+        primary_txtp: suites.primary_txtp ?? suites.txtp,
+        primary_txtp_version: suites.primary_txtp_version ?? suites.txtp_version ?? suites.version,
+        wizard_progress: suites.wizard_progress ?? { step: 1, completed: false },
+      };
+      return await this.adminServiceClient.createSimulationSuite(token, payload);
+    } catch (err) {
+      const error = err as Error;
+      this.logger.error('Error creating simulation suite', error.stack);
+      throw error;
+    }
+  }
+
+  async patchSimulationSuite(token: string, id: number, payload: PatchSimulationSuitesDto): Promise<SimulationSuitesDto> {
+    try {
+      const normalizedPayload: PatchSimulationSuitesDto = {
+        name: payload.name,
+        description: payload.description,
+        simulation_type: payload.simulation_type,
+        status: payload.status,
+        rule_repo: payload.rule_repo,
+        rule_version: payload.rule_version,
+        clone_source_suite_id: payload.clone_source_suite_id,
+        iteration_count: payload.iteration_count,
+        run_count: payload.run_count,
+        last_run_at: payload.last_run_at,
+        wizard_progress: payload.wizard_progress,
+        metadata: payload.metadata,
+        rule_name: payload.rule_name ?? payload.associated_rule,
+        primary_txtp: payload.primary_txtp ?? payload.txtp,
+        primary_txtp_version: payload.primary_txtp_version ?? payload.txtp_version ?? payload.version,
+      };
+      return await this.adminServiceClient.patchSimulationSuite(token, id, normalizedPayload);
+    } catch (err) {
+      const error = err as Error;
+      this.logger.error(`Error patching simulation suite with id: ${id}`, error.stack);
+      throw error;
+    }
+  }
+}

--- a/backend/src/services/simulation-studio/simulation-studio.service.ts
+++ b/backend/src/services/simulation-studio/simulation-studio.service.ts
@@ -3,6 +3,7 @@ import { AdminServiceClient } from '../admin-service-client';
 import {
   PatchSimulationSuitesDto,
   RequestSimulationSuitesDto,
+  SimulationSuiteResponseDto,
   SimulationSuitesDto,
   SimulationSuitesListDto,
   SimulationSuitesQueryDto,
@@ -34,7 +35,7 @@ export class SimulationStudioService {
     }
   }
 
-  async getSimulationSuiteById(token: string, id: number): Promise<SimulationSuitesDto> {
+  async getSimulationSuiteById(token: string, id: number): Promise<SimulationSuiteResponseDto> {
     try {
       return await this.adminServiceClient.getSimulationSuiteById(token, id);
     } catch (err) {
@@ -68,7 +69,7 @@ export class SimulationStudioService {
     }
   }
 
-  async patchSimulationSuite(token: string, id: number, payload: PatchSimulationSuitesDto): Promise<SimulationSuitesDto> {
+  async patchSimulationSuite(token: string, id: number, payload: PatchSimulationSuitesDto): Promise<SimulationSuiteResponseDto> {
     try {
       const normalizedPayload: PatchSimulationSuitesDto = {
         name: payload.name,

--- a/backend/src/utils/enums/simulation.enum.ts
+++ b/backend/src/utils/enums/simulation.enum.ts
@@ -2,3 +2,16 @@ export enum SimulationLogCategory {
   READ_ONLY = 'read_only',
   END_TO_END = 'end_to_end',
 }
+
+export enum SimulationSuiteType {
+  SINGLE_RULE = 'SINGLE_RULE',
+  INTEGRATION_TESTING = 'INTEGRATION_TESTING',
+}
+
+export enum SimulationSuiteStatus {
+  DRAFT = 'DRAFT',
+  RUNNING = 'RUNNING',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+  ARCHIVED = 'ARCHIVED',
+}

--- a/backend/test/simulation-studio/simulation-studio.controller.spec.ts
+++ b/backend/test/simulation-studio/simulation-studio.controller.spec.ts
@@ -6,6 +6,7 @@ import { makeAuthenticatedUser } from '../helpers/rbac/user.factory';
 import type {
   PatchSimulationSuitesDto,
   RequestSimulationSuitesDto,
+  SimulationSuiteResponseDto,
   SimulationSuitesDto,
   SimulationSuitesListDto,
   SimulationSuitesQueryDto,
@@ -36,10 +37,16 @@ describe('SimulationStudioController', () => {
   };
 
   const mockList: SimulationSuitesListDto = {
+    success: true,
+    message: 'Simulation suites retrieved successfully',
     suites: [mockSuite],
     total: 1,
-    limit: 10,
-    offset: 0,
+  };
+
+  const mockSuiteResponse: SimulationSuiteResponseDto = {
+    success: true,
+    message: 'Simulation suite updated successfully',
+    suite: mockSuite,
   };
 
   beforeEach(async () => {
@@ -89,11 +96,11 @@ describe('SimulationStudioController', () => {
 
   it('getSimulationSuiteById delegates with token and id', async () => {
     const user = makeUser();
-    service.getSimulationSuiteById.mockResolvedValue(mockSuite);
+    service.getSimulationSuiteById.mockResolvedValue(mockSuiteResponse);
 
     const result = await controller.getSimulationSuiteById(101, user);
 
-    expect(result).toEqual(mockSuite);
+    expect(result).toEqual(mockSuiteResponse);
     expect(service.getSimulationSuiteById).toHaveBeenCalledWith(user.token.tokenString, 101);
   });
 
@@ -116,11 +123,11 @@ describe('SimulationStudioController', () => {
   it('patchSimulationSuite delegates with token, id and payload', async () => {
     const user = makeUser();
     const patch: PatchSimulationSuitesDto = { status: 'RUNNING' as any } as PatchSimulationSuitesDto;
-    service.patchSimulationSuite.mockResolvedValue(mockSuite);
+    service.patchSimulationSuite.mockResolvedValue(mockSuiteResponse);
 
     const result = await controller.patchSimulationSuite(101, patch, user);
 
-    expect(result).toEqual(mockSuite);
+    expect(result).toEqual(mockSuiteResponse);
     expect(service.patchSimulationSuite).toHaveBeenCalledWith(user.token.tokenString, 101, patch);
   });
 });

--- a/backend/test/simulation-studio/simulation-studio.controller.spec.ts
+++ b/backend/test/simulation-studio/simulation-studio.controller.spec.ts
@@ -1,0 +1,126 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { SimulationStudioController } from '../../src/services/simulation-studio/simulation-studio.controller';
+import { SimulationStudioService } from '../../src/services/simulation-studio/simulation-studio.service';
+import { makeAuthenticatedUser } from '../helpers/rbac/user.factory';
+import type {
+  PatchSimulationSuitesDto,
+  RequestSimulationSuitesDto,
+  SimulationSuitesDto,
+  SimulationSuitesListDto,
+  SimulationSuitesQueryDto,
+} from '../../src/services/simulation-studio/dto';
+
+describe('SimulationStudioController', () => {
+  let controller: SimulationStudioController;
+  let service: jest.Mocked<SimulationStudioService>;
+
+  const makeUser = makeAuthenticatedUser;
+
+  const mockSuite: SimulationSuitesDto = {
+    id: '101',
+    tenant_id: 'tenant_001',
+    name: 'Q3 Edge Cases',
+    description: 'step-1 payload',
+    simulation_type: 'SINGLE_RULE' as any,
+    status: 'DRAFT' as any,
+    rule_name: 'Rule 002',
+    rule_version: 'v1.0',
+    primary_txtp: 'pacs.008',
+    primary_txtp_version: 'v1.0',
+    iteration_count: 0,
+    run_count: 0,
+    wizard_progress: {},
+    metadata: {},
+    created_by: 'user-1',
+  };
+
+  const mockList: SimulationSuitesListDto = {
+    suites: [mockSuite],
+    total: 1,
+    limit: 10,
+    offset: 0,
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SimulationStudioController],
+      providers: [
+        {
+          provide: 'AUDIT_LOGGER',
+          useValue: {
+            logEvent: jest.fn(),
+          },
+        },
+        {
+          provide: SimulationStudioService,
+          useValue: {
+            getSimulationSuites: jest.fn(),
+            getSimulationSuiteById: jest.fn(),
+            createSimulationSuites: jest.fn(),
+            patchSimulationSuite: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<SimulationStudioController>(SimulationStudioController);
+    service = module.get(SimulationStudioService);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('getSimulationSuites delegates with token and query', async () => {
+    const user = makeUser();
+    const query: SimulationSuitesQueryDto = { search: 'Q3' } as SimulationSuitesQueryDto;
+    service.getSimulationSuites.mockResolvedValue(mockList);
+
+    const result = await controller.getSimulationSuites(user, query);
+
+    expect(result).toEqual(mockList);
+    expect(service.getSimulationSuites).toHaveBeenCalledWith(user.token.tokenString, query);
+  });
+
+  it('getSimulationSuiteById delegates with token and id', async () => {
+    const user = makeUser();
+    service.getSimulationSuiteById.mockResolvedValue(mockSuite);
+
+    const result = await controller.getSimulationSuiteById(101, user);
+
+    expect(result).toEqual(mockSuite);
+    expect(service.getSimulationSuiteById).toHaveBeenCalledWith(user.token.tokenString, 101);
+  });
+
+  it('createSimulationSuites delegates with token and payload', async () => {
+    const user = makeUser();
+    const body: RequestSimulationSuitesDto = {
+      name: 'Q3 Edge Cases',
+      associated_rule: 'Rule 002',
+      txtp: 'pacs.008',
+      version: 'v1.0',
+    } as RequestSimulationSuitesDto;
+    service.createSimulationSuites.mockResolvedValue(mockSuite);
+
+    const result = await controller.createSimulationSuites(body, user);
+
+    expect(result).toEqual(mockSuite);
+    expect(service.createSimulationSuites).toHaveBeenCalledWith(user.token.tokenString, body);
+  });
+
+  it('patchSimulationSuite delegates with token, id and payload', async () => {
+    const user = makeUser();
+    const patch: PatchSimulationSuitesDto = { status: 'RUNNING' as any } as PatchSimulationSuitesDto;
+    service.patchSimulationSuite.mockResolvedValue(mockSuite);
+
+    const result = await controller.patchSimulationSuite(101, patch, user);
+
+    expect(result).toEqual(mockSuite);
+    expect(service.patchSimulationSuite).toHaveBeenCalledWith(user.token.tokenString, 101, patch);
+  });
+});

--- a/backend/test/simulation-studio/simulation-studio.service.spec.ts
+++ b/backend/test/simulation-studio/simulation-studio.service.spec.ts
@@ -1,0 +1,146 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { SimulationStudioService } from '../../src/services/simulation-studio/simulation-studio.service';
+import { AdminServiceClient } from '../../src/services/admin-service-client';
+import type {
+  PatchSimulationSuitesDto,
+  RequestSimulationSuitesDto,
+  SimulationSuitesDto,
+  SimulationSuitesListDto,
+  SimulationSuitesQueryDto,
+} from '../../src/services/simulation-studio/dto';
+
+describe('SimulationStudioService', () => {
+  let service: SimulationStudioService;
+  let adminServiceClient: jest.Mocked<AdminServiceClient>;
+
+  const mockSuite: SimulationSuitesDto = {
+    id: '101',
+    tenant_id: 'tenant_001',
+    name: 'Q3 Edge Cases',
+    description: 'step-1 payload',
+    simulation_type: 'SINGLE_RULE' as any,
+    status: 'DRAFT' as any,
+    rule_name: 'Rule 002',
+    rule_version: 'v1.0',
+    primary_txtp: 'pacs.008',
+    primary_txtp_version: 'v1.0',
+    iteration_count: 0,
+    run_count: 0,
+    wizard_progress: {},
+    metadata: {},
+    created_by: 'user-1',
+  };
+
+  const mockList: SimulationSuitesListDto = {
+    suites: [mockSuite],
+    total: 1,
+    limit: 10,
+    offset: 0,
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SimulationStudioService,
+        {
+          provide: AdminServiceClient,
+          useValue: {
+            getSimulationSuites: jest.fn(),
+            getSimulationSuiteById: jest.fn(),
+            createSimulationSuite: jest.fn(),
+            patchSimulationSuite: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<SimulationStudioService>(SimulationStudioService);
+    adminServiceClient = module.get(AdminServiceClient);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('getSimulationSuites forwards token and query', async () => {
+    const query: SimulationSuitesQueryDto = { search: 'Q3', limit: 10, offset: 0 } as SimulationSuitesQueryDto;
+    adminServiceClient.getSimulationSuites.mockResolvedValue(mockList);
+
+    const result = await service.getSimulationSuites('test-token', query);
+
+    expect(result).toEqual(mockList);
+    expect(adminServiceClient.getSimulationSuites).toHaveBeenCalledWith('test-token', query);
+  });
+
+  it('getSimulationSuiteById forwards token and id', async () => {
+    adminServiceClient.getSimulationSuiteById.mockResolvedValue(mockSuite);
+
+    const result = await service.getSimulationSuiteById('test-token', 101);
+
+    expect(result).toEqual(mockSuite);
+    expect(adminServiceClient.getSimulationSuiteById).toHaveBeenCalledWith('test-token', 101);
+  });
+
+  it('createSimulationSuites maps alias fields and adds default wizard progress', async () => {
+    const createDto: RequestSimulationSuitesDto = {
+      name: 'Q3 Edge Cases',
+      associated_rule: 'Rule 002',
+      txtp: 'pacs.008',
+      version: 'v1.0',
+    } as RequestSimulationSuitesDto;
+
+    adminServiceClient.createSimulationSuite.mockResolvedValue(mockSuite);
+
+    await service.createSimulationSuites('test-token', createDto);
+
+    expect(adminServiceClient.createSimulationSuite).toHaveBeenCalledWith(
+      'test-token',
+      expect.objectContaining({
+        name: 'Q3 Edge Cases',
+        rule_name: 'Rule 002',
+        primary_txtp: 'pacs.008',
+        primary_txtp_version: 'v1.0',
+        wizard_progress: { step: 1, completed: false },
+      }),
+    );
+  });
+
+  it('patchSimulationSuite maps alias fields', async () => {
+    const patchDto: PatchSimulationSuitesDto = {
+      associated_rule: 'Rule 003',
+      txtp: 'pain.001',
+      txtp_version: 'v2.0',
+      metadata: { step: 2 },
+    } as PatchSimulationSuitesDto;
+
+    adminServiceClient.patchSimulationSuite.mockResolvedValue(mockSuite);
+
+    await service.patchSimulationSuite('test-token', 101, patchDto);
+
+    expect(adminServiceClient.patchSimulationSuite).toHaveBeenCalledWith(
+      'test-token',
+      101,
+      expect.objectContaining({
+        rule_name: 'Rule 003',
+        primary_txtp: 'pain.001',
+        primary_txtp_version: 'v2.0',
+        metadata: { step: 2 },
+      }),
+    );
+  });
+
+  it('logs and rethrows create errors', async () => {
+    const createDto: RequestSimulationSuitesDto = { name: 'Q3' } as RequestSimulationSuitesDto;
+    const error = new Error('Create failed');
+    adminServiceClient.createSimulationSuite.mockRejectedValue(error);
+    const loggerSpy = jest.spyOn(service['logger'], 'error');
+
+    await expect(service.createSimulationSuites('test-token', createDto)).rejects.toThrow('Create failed');
+    expect(loggerSpy).toHaveBeenCalledWith('Error creating simulation suite', expect.any(String));
+  });
+});

--- a/backend/test/simulation-studio/simulation-studio.service.spec.ts
+++ b/backend/test/simulation-studio/simulation-studio.service.spec.ts
@@ -5,6 +5,7 @@ import { AdminServiceClient } from '../../src/services/admin-service-client';
 import type {
   PatchSimulationSuitesDto,
   RequestSimulationSuitesDto,
+  SimulationSuiteResponseDto,
   SimulationSuitesDto,
   SimulationSuitesListDto,
   SimulationSuitesQueryDto,
@@ -33,10 +34,16 @@ describe('SimulationStudioService', () => {
   };
 
   const mockList: SimulationSuitesListDto = {
+    success: true,
+    message: 'Simulation suites retrieved successfully',
     suites: [mockSuite],
     total: 1,
-    limit: 10,
-    offset: 0,
+  };
+
+  const mockSuiteResponse: SimulationSuiteResponseDto = {
+    success: true,
+    message: 'Simulation suite updated successfully',
+    suite: mockSuite,
   };
 
   beforeEach(async () => {
@@ -78,11 +85,11 @@ describe('SimulationStudioService', () => {
   });
 
   it('getSimulationSuiteById forwards token and id', async () => {
-    adminServiceClient.getSimulationSuiteById.mockResolvedValue(mockSuite);
+    adminServiceClient.getSimulationSuiteById.mockResolvedValue(mockSuiteResponse);
 
     const result = await service.getSimulationSuiteById('test-token', 101);
 
-    expect(result).toEqual(mockSuite);
+    expect(result).toEqual(mockSuiteResponse);
     expect(adminServiceClient.getSimulationSuiteById).toHaveBeenCalledWith('test-token', 101);
   });
 
@@ -118,7 +125,7 @@ describe('SimulationStudioService', () => {
       metadata: { step: 2 },
     } as PatchSimulationSuitesDto;
 
-    adminServiceClient.patchSimulationSuite.mockResolvedValue(mockSuite);
+    adminServiceClient.patchSimulationSuite.mockResolvedValue(mockSuiteResponse);
 
     await service.patchSimulationSuite('test-token', 101, patchDto);
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0
This pull request introduces the foundation for the "Simulation Studio" feature, adding new API endpoints, DTOs, and supporting types for managing simulation suites. It also includes some code cleanup and minor improvements in existing service clients and project configuration.

**Simulation Studio Feature (Core Additions):**

* Added the new `SimulationStudioModule` to the main application module (`app.module.ts`), registering it as part of the backend service imports. [[1]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R20) [[2]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R42)
* Introduced new API endpoints and constants for Simulation Studio, including base URLs and suite-specific routes in `constant.ts`.
* Created comprehensive DTOs for Simulation Suites, including create, patch, list, and query types, with validation and OpenAPI decorators (`simulation-studio/dto/index.ts`).
* Defined supporting types and interfaces for Simulation Studio, such as suite status, run status, and payload interfaces (`simulation-studio/interface/common.types.ts`, `simulation-studio/interface/simulation-studio.interface.ts`). [[1]](diffhunk://#diff-b8609cf7e7599a5f6044b73d2338a4614dc3dd40ea165d833359c5b09f4d29eeR1-R16) [[2]](diffhunk://#diff-ab34c14ac3fcdf4f96bb56019a4659278311d51eb0efeae9c072300b9e149eb5R1-R14)

**Admin Service Client Enhancements:**

* Added methods to `AdminServiceClient` for listing, retrieving, creating, and patching simulation suites, using the new Simulation Studio endpoints and DTOs. [[1]](diffhunk://#diff-49694be9498867c5f13f9523a950a3184459e6a59699ed164e063d0df91a468eR73-R74) [[2]](diffhunk://#diff-49694be9498867c5f13f9523a950a3184459e6a59699ed164e063d0df91a468eL484-R543)
* Improved method signatures and parameter handling for existing simulation-related service methods for better clarity and maintainability. [[1]](diffhunk://#diff-49694be9498867c5f13f9523a950a3184459e6a59699ed164e063d0df91a468eL426-R451) [[2]](diffhunk://#diff-49694be9498867c5f13f9523a950a3184459e6a59699ed164e063d0df91a468eL463-R471)

**Project Configuration and Cleanup:**

* Updated the `lint-staged` configuration in `package.json` to use `eslint --fix` and `prettier --write` directly, improving developer workflow.

These changes lay the groundwork for managing simulation suites in the backend, enabling future development of Simulation Studio features.
## What did we change?

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done