### PR TITLE
feat: frontend simulation studio version 1

### DIFF
--- a/frontend/src/components/Cards/StatusCard/Status.styles.ts
+++ b/frontend/src/components/Cards/StatusCard/Status.styles.ts
@@ -72,6 +72,24 @@ export const getStatusStyles = (status: string, theme: Theme) => {
                 color: '#e7000b',
                 borderColor: '#ffc9c9',
             };
+        case "Ready for Simulation":
+            return {
+                backgroundColor: '#f0fdf4',
+                color: '#00a63e',
+                borderColor: '#ddfbe8',
+            };
+        case "Draft":
+            return {
+                backgroundColor: theme.palette.grey[100],
+                color: theme.palette.grey[700],
+                borderColor: theme.palette.grey[300],
+            };
+        case "Generated":
+            return {
+                backgroundColor: '#eef2ff',
+                color: '#5641f6',
+                borderColor: '#e1e8ff',
+            };
         default:
             return {
                 backgroundColor: theme.palette.grey[100],

--- a/frontend/src/components/SimStudio/PlaceholderStep.tsx
+++ b/frontend/src/components/SimStudio/PlaceholderStep.tsx
@@ -1,0 +1,30 @@
+import ConstructionOutlinedIcon from "@mui/icons-material/ConstructionOutlined";
+import { Box } from "@mui/material";
+import { Text } from "../Text";
+
+interface PlaceholderStepProps {
+    title: string;
+}
+
+const PlaceholderStep = ({ title }: PlaceholderStepProps) => (
+    <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        py={10}
+        gap={2}
+        width="100%"
+        maxWidth="700px"
+    >
+        <ConstructionOutlinedIcon sx={{ fontSize: 52, color: "text.ternary" }} />
+        <Text size="header" weight="bold" color="text.ternary">
+            {title}
+        </Text>
+        <Text size="body" color="text.ternary">
+            This step will be implemented in future iterations.
+        </Text>
+    </Box>
+);
+
+export default PlaceholderStep;

--- a/frontend/src/components/SimStudio/RuleDetails/index.tsx
+++ b/frontend/src/components/SimStudio/RuleDetails/index.tsx
@@ -1,0 +1,151 @@
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import { Box, Typography } from "@mui/material";
+import Grid from "@mui/material/Grid";
+import { Controller, type Control, type FieldErrors } from "react-hook-form";
+import DropDown, { type DropdownOption } from "../../DropDown";
+import Input from "../../Input";
+import Loader from "../../Loader";
+import * as S from "../../../pages/SimStudio/CreateSimSuite/CreateSimSuite.styles";
+import type { Step1Values } from "../../../hooks/SimStudio/useCreateSimSuiteController";
+
+interface Step1Props {
+    control: Control<Step1Values>;
+    errors: FieldErrors<Step1Values>;
+    txTypeOptions: DropdownOption[];
+    versionOptions: DropdownOption[];
+    ruleOptions: DropdownOption[];
+    ruleVersionOptions: DropdownOption[];
+    txLoading: boolean;
+    versionLoading: boolean;
+}
+
+const Step1RuleDetails = ({
+    control,
+    errors,
+    txTypeOptions,
+    versionOptions,
+    ruleOptions,
+    ruleVersionOptions,
+    txLoading,
+    versionLoading,
+}: Step1Props) => {
+    if (txLoading) return <Loader center />;
+
+    return (
+        <Box width="100%" maxWidth="700px" display="flex" flexDirection="column">
+            <S.InfoBanner>
+                <InfoOutlinedIcon sx={{ color: "#3b82f6", fontSize: 18, flexShrink: 0, mt: "1px" }} />
+                <Typography fontSize={13} color="#1d4ed8" lineHeight={1.5}>
+                    Define the simulation suite metadata and optionally associate it with a rule.
+                </Typography>
+            </S.InfoBanner>
+            <S.FormCard>
+                <Grid container spacing={2.5}>
+                    <Grid size={12}>
+                        <Controller
+                            control={control}
+                            name="suite_name"
+                            render={({ field }) => (
+                                <Input
+                                    maxWidth="100%"
+                                    required
+                                    label="Simulation Suite Name"
+                                    placeholder="e.g., Q3 Edge Cases"
+                                    {...field}
+                                    error={errors.suite_name?.message}
+                                />
+                            )}
+                        />
+                    </Grid>
+                    <Grid size={12}>
+                        <Controller
+                            control={control}
+                            name="description"
+                            render={({ field }) => (
+                                <Input
+                                    maxWidth="100%"
+                                    type="textarea"
+                                    rows={4}
+                                    label="Description"
+                                    placeholder="Describe the purpose of this simulation suite..."
+                                    {...field}
+                                />
+                            )}
+                        />
+                    </Grid>
+                    <Grid size={{ xs: 12, md: 6 }}>
+                        <Controller
+                            control={control}
+                            name="associated_rule"
+                            render={({ field }) => (
+                                <DropDown
+                                    label="Associated Rule"
+                                    placeholder="Select a rule..."
+                                    options={ruleOptions}
+                                    value={field.value ?? null}
+                                    onChange={(val) => field.onChange(val)}
+                                    error={errors.associated_rule?.message as string | undefined}
+                                />
+                            )}
+                        />
+                    </Grid>
+                    <Grid size={{ xs: 12, md: 6 }}>
+                        <Controller
+                            control={control}
+                            name="rule_version"
+                            render={({ field, fieldState: { error } }) => (
+                                <DropDown
+                                    label="Rule Version"
+                                    placeholder="Select version..."
+                                    options={ruleVersionOptions}
+                                    value={field.value ?? null}
+                                    onChange={(val) => field.onChange(val)}
+                                    disabled={ruleVersionOptions.length === 0}
+                                    error={error?.message}
+                                />
+                            )}
+                        />
+                    </Grid>
+                    <Grid size={{ xs: 12, md: 6 }}>
+                        <Controller
+                            control={control}
+                            name="txtp"
+                            render={({ field }) => (
+                                <DropDown
+                                    required
+                                    label="TXTP"
+                                    placeholder="Select TXTP..."
+                                    options={txTypeOptions}
+                                    searchable
+                                    value={field.value ?? null}
+                                    onChange={(val) => field.onChange(val)}
+                                    error={errors.txtp?.message as string | undefined}
+                                />
+                            )}
+                        />
+                    </Grid>
+                    <Grid size={{ xs: 12, md: 6 }}>
+                        <Controller
+                            control={control}
+                            name="version"
+                            render={({ field }) => (
+                                <DropDown
+                                    required
+                                    label="Version"
+                                    placeholder="Select version..."
+                                    options={versionOptions}
+                                    value={field.value ?? null}
+                                    onChange={(val) => field.onChange(val)}
+                                    disabled={versionOptions.length === 0 || versionLoading}
+                                    error={errors.version?.message as string | undefined}
+                                />
+                            )}
+                        />
+                    </Grid>
+                </Grid>
+            </S.FormCard>
+        </Box>
+    );
+};
+
+export default Step1RuleDetails;

--- a/frontend/src/components/SimStudio/TxtpSelection/TxtpSelection.styles.ts
+++ b/frontend/src/components/SimStudio/TxtpSelection/TxtpSelection.styles.ts
@@ -1,0 +1,94 @@
+import { Box, styled, Typography } from "@mui/material";
+
+export const InfoBanner = styled(Box)(({ theme }) => ({
+    display: "flex",
+    alignItems: "flex-start",
+    gap: theme.spacing(1.5),
+    padding: theme.spacing(1.5, 2),
+    backgroundColor: "#eff6ff",
+    border: "1px solid #bfdbfe",
+    borderRadius: "8px",
+    marginBottom: theme.spacing(3),
+}));
+
+export const AddFormCard = styled(Box)(({ theme }) => ({
+    display: "flex",
+    alignItems: "flex-end",
+    gap: theme.spacing(2),
+    flexWrap: "wrap",
+    padding: theme.spacing(2, 2.5),
+    backgroundColor: "#fff",
+    border: "1px solid #e5e7eb",
+    borderRadius: "8px",
+    marginBottom: theme.spacing(2.5),
+}));
+
+export const FieldLabel = styled(Typography)(() => ({
+    fontSize: "12px",
+    fontWeight: 500,
+    color: "#6b7280",
+    marginBottom: "6px",
+}));
+
+export const PrimaryBadge = styled(Box)(() => ({
+    display: "inline-flex",
+    alignItems: "center",
+    padding: "1px 8px",
+    borderRadius: "4px",
+    fontSize: "10px",
+    fontWeight: 700,
+    letterSpacing: "0.05em",
+    textTransform: "uppercase" as const,
+    backgroundColor: "#eff6ff",
+    color: "#2563eb",
+    border: "1px solid #bfdbfe",
+    marginLeft: "8px",
+    verticalAlign: "middle",
+}));
+
+export const StatusBadge = styled(Box, {
+    shouldForwardProp: (prop) => prop !== "variant",
+})<{ variant: "success" | "default" }>(({ variant }) => ({
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "4px",
+    padding: "2px 10px",
+    borderRadius: "20px",
+    fontSize: "11px",
+    fontWeight: 500,
+    whiteSpace: "nowrap" as const,
+    backgroundColor: variant === "success" ? "#dcfce7" : "#f3f4f6",
+    color: variant === "success" ? "#15803d" : "#6b7280",
+}));
+
+export const RemoveText = styled(Typography)(() => ({
+    fontSize: "13px",
+    fontWeight: 500,
+    color: "#ef4444",
+    cursor: "pointer",
+    "&:hover": { textDecoration: "underline" },
+}));
+
+export const FieldConfigSection = styled(Box)(({ theme }) => ({
+    padding: theme.spacing(2, 2.5),
+    backgroundColor: "#fafafa",
+    borderTop: "1px solid #e5e7eb",
+}));
+
+export const FieldConfigHeader = styled(Box)(() => ({
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: "12px",
+}));
+
+export const FieldConfigTitle = styled(Typography)(() => ({
+    fontSize: "13px",
+    fontWeight: 600,
+    color: "#111827",
+}));
+
+export const FieldConfigSubtitle = styled(Typography)(() => ({
+    fontSize: "12px",
+    color: "#6b7280",
+}));

--- a/frontend/src/components/SimStudio/TxtpSelection/index.tsx
+++ b/frontend/src/components/SimStudio/TxtpSelection/index.tsx
@@ -302,7 +302,7 @@ const TxtpSelection = () => {
     } = values;
 
     const {
-        setAddTxtp,
+        handleTxtpChange,
         setAddVersion,
         setNumMessages,
         handleAdd,
@@ -327,7 +327,7 @@ const TxtpSelection = () => {
                     <S.FieldLabel>TXTP Type</S.FieldLabel>
                     <DropDown
                         value={addTxtp}
-                        onChange={(value) => setAddTxtp(value as typeof addTxtp)}
+                        onChange={(value) => handleTxtpChange(value as typeof addTxtp)}
                         options={txTypeOptions}
                         placeholder="Select type"
                         searchable

--- a/frontend/src/components/SimStudio/TxtpSelection/index.tsx
+++ b/frontend/src/components/SimStudio/TxtpSelection/index.tsx
@@ -1,0 +1,427 @@
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import {
+    Box,
+    Collapse,
+    IconButton,
+    MenuItem,
+    Paper,
+    Select,
+    Table as MuiTable,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    TextField,
+    Tooltip,
+    Typography,
+} from "@mui/material";
+import Button from "../../Button";
+import DropDown from "../../DropDown";
+import { Text } from "../../Text";
+import useTxtpSelectionController, {
+    type FieldAction,
+    type FieldConfig,
+    type TxtpEntry,
+} from "../../../hooks/SimStudio/useTxtpSelectionController";
+import * as S from "./TxtpSelection.styles";
+
+interface FieldConfigTableProps {
+    entry: TxtpEntry;
+    onFieldConfigChange: (entryId: string, path: string, config: FieldConfig) => void;
+}
+
+interface EntryRowProps {
+    entry: TxtpEntry;
+    index: number;
+    isPrimary: boolean;
+    onToggle: (id: string) => void;
+    onRemove: (id: string) => void;
+    onFieldConfigChange: (entryId: string, path: string, config: FieldConfig) => void;
+}
+
+const FIELD_ACTION_OPTIONS: { label: string; value: FieldAction }[] = [
+    { label: "Use Sample Value", value: "sample" },
+    { label: "Set Static Value", value: "static" },
+    { label: "Use Range", value: "range" },
+    { label: "Skip Field", value: "skip" },
+];
+
+const FieldConfigTable = ({ entry, onFieldConfigChange }: FieldConfigTableProps) => {
+    const getConfig = (path: string): FieldConfig =>
+        entry.fieldConfigs[path] ?? { action: "sample", staticValue: "", rangeStart: "", rangeEnd: "" };
+
+    return (
+        <S.FieldConfigSection>
+            <S.FieldConfigHeader>
+                <S.FieldConfigTitle>
+                    Field Configuration for {entry.txtp}
+                </S.FieldConfigTitle>
+                <S.FieldConfigSubtitle>
+                    Configure only the fields relevant to the rule. Unconfigured fields may
+                    keep sample values or defaults.
+                </S.FieldConfigSubtitle>
+            </S.FieldConfigHeader>
+
+            <TableContainer
+                component={Paper}
+                variant="outlined"
+                sx={{ maxHeight: 340, overflowY: "auto" }}
+            >
+                <MuiTable stickyHeader size="small">
+                    <TableHead>
+                        <TableRow>
+                            <TableCell
+                                sx={{
+                                    fontWeight: 600,
+                                    fontSize: "12px",
+                                    bgcolor: "#fbf9fa",
+                                    width: "30%",
+                                }}
+                            >
+                                Field Name
+                            </TableCell>
+                            <TableCell
+                                sx={{ fontWeight: 600, fontSize: "12px", bgcolor: "#fbf9fa", width: "18%" }}
+                            >
+                                Action
+                            </TableCell>
+                            <TableCell
+                                sx={{ fontWeight: 600, fontSize: "12px", bgcolor: "#fbf9fa", width: "22%" }}
+                            >
+                                Static Value
+                            </TableCell>
+                            <TableCell
+                                sx={{ fontWeight: 600, fontSize: "12px", bgcolor: "#fbf9fa" }}
+                            >
+                                Range
+                            </TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {entry.fieldPaths.length === 0 ? (
+                            <TableRow>
+                                <TableCell colSpan={4} align="center" sx={{ py: 3, color: "#9ca3af" }}>
+                                    No fields available from payload
+                                </TableCell>
+                            </TableRow>
+                        ) : (
+                            entry.fieldPaths.map((path) => {
+                                const config = getConfig(path);
+                                return (
+                                    <TableRow key={path} hover>
+                                        <TableCell
+                                            sx={{
+                                                fontSize: "12px",
+                                                color: "#2563eb",
+                                                fontFamily: "monospace",
+                                                borderBottom: "1px solid #e0e0e0",
+                                                maxWidth: 0,
+                                                overflow: "hidden",
+                                            }}
+                                        >
+                                            <Tooltip title={path} placement="top-start">
+                                                <span
+                                                    style={{
+                                                        display: "block",
+                                                        overflow: "hidden",
+                                                        textOverflow: "ellipsis",
+                                                        whiteSpace: "nowrap",
+                                                    }}
+                                                >
+                                                    {path}
+                                                </span>
+                                            </Tooltip>
+                                        </TableCell>
+                                        <TableCell sx={{ borderBottom: "1px solid #e0e0e0" }}>
+                                            <Select
+                                                value={config.action}
+                                                size="small"
+                                                onChange={(e) => {
+                                                    const newAction = e.target.value as FieldAction;
+                                                    onFieldConfigChange(entry.id, path, {
+                                                        action: newAction,
+                                                        staticValue: newAction === "static" ? config.staticValue : "",
+                                                        rangeStart: newAction === "range" ? config.rangeStart : "",
+                                                        rangeEnd: newAction === "range" ? config.rangeEnd : "",
+                                                    });
+                                                }}
+                                                sx={{
+                                                    fontSize: "12px",
+                                                    minWidth: 160,
+                                                    "& .MuiSelect-select": { py: "4px" },
+                                                }}
+                                            >
+                                                {FIELD_ACTION_OPTIONS.map((opt) => (
+                                                    <MenuItem key={opt.value} value={opt.value} sx={{ fontSize: "12px" }}>
+                                                        {opt.label}
+                                                    </MenuItem>
+                                                ))}
+                                            </Select>
+                                        </TableCell>
+                                        <TableCell sx={{ borderBottom: "1px solid #e0e0e0" }}>
+                                            {config.action === "static" ? (
+                                                <TextField
+                                                    size="small"
+                                                    value={config.staticValue}
+                                                    placeholder="Enter value"
+                                                    onChange={(e) =>
+                                                        onFieldConfigChange(entry.id, path, {
+                                                            ...config,
+                                                            staticValue: e.target.value,
+                                                        })
+                                                    }
+                                                    sx={{ width: "100%", "& input": { fontSize: "12px", py: "4px" } }}
+                                                />
+                                            ) : (
+                                                <Typography sx={{ fontSize: "12px", color: "#d1d5db" }}>—</Typography>
+                                            )}
+                                        </TableCell>
+                                        <TableCell sx={{ borderBottom: "1px solid #e0e0e0" }}>
+                                            {config.action === "range" ? (
+                                                <Box display="flex" alignItems="center" gap={0.5}>
+                                                    <TextField
+                                                        size="small"
+                                                        value={config.rangeStart}
+                                                        placeholder="Start"
+                                                        onChange={(e) =>
+                                                            onFieldConfigChange(entry.id, path, {
+                                                                ...config,
+                                                                rangeStart: e.target.value,
+                                                            })
+                                                        }
+                                                        sx={{ width: 90, "& input": { fontSize: "12px", py: "4px" } }}
+                                                    />
+                                                    <Typography sx={{ fontSize: "12px", color: "#9ca3af", px: 0.25 }}>–</Typography>
+                                                    <TextField
+                                                        size="small"
+                                                        value={config.rangeEnd}
+                                                        placeholder="End"
+                                                        onChange={(e) =>
+                                                            onFieldConfigChange(entry.id, path, {
+                                                                ...config,
+                                                                rangeEnd: e.target.value,
+                                                            })
+                                                        }
+                                                        sx={{ width: 90, "& input": { fontSize: "12px", py: "4px" } }}
+                                                    />
+                                                </Box>
+                                            ) : (
+                                                <Typography sx={{ fontSize: "12px", color: "#d1d5db" }}>—</Typography>
+                                            )}
+                                        </TableCell>
+                                    </TableRow>
+                                );
+                            })
+                        )}
+                    </TableBody>
+                </MuiTable>
+            </TableContainer>
+        </S.FieldConfigSection>
+    );
+};
+
+const EntryRow = ({
+    entry,
+    index,
+    isPrimary,
+    onToggle,
+    onRemove,
+    onFieldConfigChange,
+}: EntryRowProps) => (
+    <>
+        <TableRow hover sx={{ bgcolor: "#fff" }}>
+            <TableCell sx={{ width: 48, borderBottom: "1px solid #e0e0e0", pr: 0 }}>
+                <IconButton size="small" onClick={() => onToggle(entry.id)}>
+                    {entry.expanded ? (
+                        <ExpandMoreIcon sx={{ fontSize: 16 }} />
+                    ) : (
+                        <ChevronRightIcon sx={{ fontSize: 16 }} />
+                    )}
+                </IconButton>
+            </TableCell>
+            <TableCell sx={{ fontWeight: 500, fontSize: "13px", borderBottom: "1px solid #e0e0e0" }}>
+                {index + 1}
+            </TableCell>
+            <TableCell sx={{ borderBottom: "1px solid #e0e0e0" }}>
+                <Box display="flex" alignItems="center">
+                    <Typography sx={{ fontSize: "13px", fontWeight: 600 }}>{entry.txtp}</Typography>
+                    {isPrimary && <S.PrimaryBadge>Primary</S.PrimaryBadge>}
+                </Box>
+            </TableCell>
+            <TableCell sx={{ fontSize: "13px", borderBottom: "1px solid #e0e0e0" }}>
+                {entry.version}
+            </TableCell>
+            <TableCell sx={{ borderBottom: "1px solid #e0e0e0" }}>
+                <Box display="flex" gap={1} flexWrap="wrap">
+                    <S.StatusBadge variant={entry.schemaLoaded ? "success" : "default"}>
+                        <CheckCircleOutlineIcon sx={{ fontSize: 12 }} />
+                        Schema {entry.schemaLoaded ? "Loaded" : "Not Loaded"}
+                    </S.StatusBadge>
+                    <S.StatusBadge variant={entry.sampleAvailable ? "success" : "default"}>
+                        <CheckCircleOutlineIcon sx={{ fontSize: 12 }} />
+                        Sample {entry.sampleAvailable ? "Available" : "Unavailable"}
+                    </S.StatusBadge>
+                </Box>
+            </TableCell>
+            <TableCell sx={{ borderBottom: "1px solid #e0e0e0" }}>
+                {!isPrimary && (
+                    <S.RemoveText onClick={() => onRemove(entry.id)}>Remove</S.RemoveText>
+                )}
+            </TableCell>
+        </TableRow>
+
+        <TableRow>
+            <TableCell colSpan={6} sx={{ p: 0, borderBottom: entry.expanded ? "1px solid #e0e0e0" : "none" }}>
+                <Collapse in={entry.expanded} timeout="auto" unmountOnExit>
+                    <FieldConfigTable
+                        entry={entry}
+                        onFieldConfigChange={onFieldConfigChange}
+                    />
+                </Collapse>
+            </TableCell>
+        </TableRow>
+    </>
+);
+
+const TxtpSelection = () => {
+    const { values, functions } = useTxtpSelectionController();
+
+    const {
+        entries,
+        txTypeOptions,
+        addTxtp,
+        addVersion,
+        addVersionOptions,
+        addVersionsLoading,
+        numMessages,
+        adding,
+    } = values;
+
+    const {
+        setAddTxtp,
+        setAddVersion,
+        setNumMessages,
+        handleAdd,
+        handleRemove,
+        handleToggleExpand,
+        handleFieldConfigChange,
+    } = functions;
+
+    return (
+        <Box>
+            <S.InfoBanner>
+                <InfoOutlinedIcon sx={{ fontSize: 18, color: "#3b82f6", flexShrink: 0, mt: "1px" }} />
+                <Text size="sub" sx={{ color: "#1e40af", lineHeight: 1.6 }}>
+                    TXTP schemas, sample payloads, and mapping configurations are used to generate
+                    valid synthetic messages. The first TXTP in the list is marked as{" "}
+                    <strong>Primary</strong>, meaning it will act as the root trigger message for
+                    the simulation transaction.
+                </Text>
+            </S.InfoBanner>
+            <S.AddFormCard>
+                <Box flex="1" minWidth={160}>
+                    <S.FieldLabel>TXTP Type</S.FieldLabel>
+                    <DropDown
+                        value={addTxtp}
+                        onChange={(value) => setAddTxtp(value as typeof addTxtp)}
+                        options={txTypeOptions}
+                        placeholder="Select type"
+                        searchable
+                    />
+                </Box>
+
+                <Box flex="1" minWidth={140}>
+                    <S.FieldLabel>Version</S.FieldLabel>
+                    <DropDown
+                        value={addVersion}
+                        onChange={(value) => setAddVersion(value as typeof addVersion)}
+                        options={addVersionOptions}
+                        placeholder="Select version"
+                        disabled={!addTxtp || addVersionsLoading}
+                    />
+                </Box>
+
+                <Box minWidth={140}>
+                    <S.FieldLabel>No. of Messages</S.FieldLabel>
+                    <TextField
+                        type="number"
+                        size="small"
+                        value={numMessages}
+                        inputProps={{ min: 1 }}
+                        onChange={(e) => setNumMessages(Math.max(1, Number(e.target.value)))}
+                        sx={{
+                            width: "100%",
+                            "& .MuiOutlinedInput-root": {
+                                borderRadius: "6px",
+                                fontSize: "14px",
+                                height: "38px",
+                            },
+                        }}
+                    />
+                </Box>
+
+                <Box flexShrink={0}>
+                    <Button
+                        height="38px"
+                        type="secondary"
+                        size="md"
+                        text="Add TXTP"
+                        loading={adding}
+                        onClick={handleAdd}
+                    />
+                </Box>
+            </S.AddFormCard>
+            <TableContainer component={Paper} variant="outlined">
+                <MuiTable>
+                    <TableHead>
+                        <TableRow>
+                            <TableCell sx={{ width: 48, bgcolor: "#fbf9fa", fontWeight: 600, fontSize: "13px", pr: 0 }} />
+                            <TableCell sx={{ bgcolor: "#fbf9fa", fontWeight: 600, fontSize: "13px" }}>
+                                Order
+                            </TableCell>
+                            <TableCell sx={{ bgcolor: "#fbf9fa", fontWeight: 600, fontSize: "13px" }}>
+                                TXTP
+                            </TableCell>
+                            <TableCell sx={{ bgcolor: "#fbf9fa", fontWeight: 600, fontSize: "13px" }}>
+                                Version
+                            </TableCell>
+                            <TableCell sx={{ bgcolor: "#fbf9fa", fontWeight: 600, fontSize: "13px" }}>
+                                Schema Status
+                            </TableCell>
+                            <TableCell sx={{ bgcolor: "#fbf9fa", fontWeight: 600, fontSize: "13px" }}>
+                                Action
+                            </TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {entries.length === 0 ? (
+                            <TableRow>
+                                <TableCell colSpan={6} align="center" sx={{ py: 4, color: "#9ca3af" }}>
+                                    No TXTPs added yet
+                                </TableCell>
+                            </TableRow>
+                        ) : (
+                            entries.map((entry, idx) => (
+                                <EntryRow
+                                    key={entry.id}
+                                    entry={entry}
+                                    index={idx}
+                                    isPrimary={idx === 0}
+                                    onToggle={handleToggleExpand}
+                                    onRemove={handleRemove}
+                                    onFieldConfigChange={handleFieldConfigChange}
+                                />
+                            ))
+                        )}
+                    </TableBody>
+                </MuiTable>
+            </TableContainer>
+        </Box>
+    );
+};
+
+export default TxtpSelection;

--- a/frontend/src/components/Tabs/index.tsx
+++ b/frontend/src/components/Tabs/index.tsx
@@ -3,6 +3,7 @@ import { useTab } from "../../contexts/TabContext/useTab";
 import { useMaskingTab } from "../../contexts/MaskingTabContext/useMaskingTab";
 import * as S from './Tabs.styles';
 import { useSimulationTab } from "../../contexts/SimulationTabContext";
+import { useSimStudioTab } from "../../contexts/SimStudioTabContext";
 
 export type TabItem = {
     label: string;
@@ -11,7 +12,7 @@ export type TabItem = {
 };
 
 interface TabsProps {
-    variant?: 'default' | 'masking' | 'simulation';
+    variant?: 'default' | 'masking' | 'simulation' | 'sim-studio';
 }
 
 const TabList = ({ tabs, selected }: { tabs: TabItem[]; selected: string }) => (
@@ -45,11 +46,18 @@ const SimulationTabs = () => {
     return <TabList tabs={tabs} selected={selectedTab} />;
 };
 
+const SimStudioTabsView = () => {
+    const { tabs, selectedTab } = useSimStudioTab();
+    return <TabList tabs={tabs} selected={selectedTab} />;
+};
+
 const Tabs = ({ variant = 'default' }: TabsProps) => {
     if (variant === 'masking') {
         return <MaskingTabs />
     } else if (variant === 'simulation') {
         return <SimulationTabs />
+    } else if (variant === 'sim-studio') {
+        return <SimStudioTabsView />
     };
     return <DefaultTabs />;
 };

--- a/frontend/src/contexts/SimStudioTabContext/SimStudioTabContext.ts
+++ b/frontend/src/contexts/SimStudioTabContext/SimStudioTabContext.ts
@@ -1,0 +1,14 @@
+import { createContext } from "react"
+import type { TabItem } from "../../components/Tabs"
+
+export interface SimStudioTabContextType {
+    selectedTab: string
+    enabledTabs: string[]
+    tabs: TabItem[]
+    setSelectedTab: (tab: string) => void
+    enableNextTab: () => void
+    enableAllTabs: () => void
+    enablePreviousTab: () => void
+}
+
+export const SimStudioTabContext = createContext<SimStudioTabContextType | undefined>(undefined)

--- a/frontend/src/contexts/SimStudioTabContext/SimStudioTabProvider.tsx
+++ b/frontend/src/contexts/SimStudioTabContext/SimStudioTabProvider.tsx
@@ -1,0 +1,76 @@
+import { useCallback, useMemo, useState } from "react"
+import { useSearchParams } from "react-router-dom"
+import { SimStudioTabs } from "../../utils/Constants/data"
+import { SimStudioTabContext } from "./SimStudioTabContext"
+
+interface SimStudioTabProviderProps {
+    children: React.ReactNode
+}
+
+export const SimStudioTabProvider = ({ children }: SimStudioTabProviderProps) => {
+    const [searchParams, setSearchParams] = useSearchParams()
+    const tabFromUrl = searchParams.get('simStudioTab') ?? SimStudioTabs[0].value
+    const [selectedTab, setSelectedTabState] = useState<string>(tabFromUrl)
+    const [enabledTabs, setEnabledTabs] = useState<string[]>([SimStudioTabs[0].value])
+    const filteredTabs = useMemo(() => SimStudioTabs, [])
+
+    const handleSetSelectedTab = useCallback((tab: string) => {
+        setSelectedTabState(tab)
+        setSearchParams((prev) => {
+            const newParams = new URLSearchParams(prev)
+            newParams.set('simStudioTab', tab)
+            return newParams
+        })
+    }, [setSearchParams])
+
+    const enableNextTab = useCallback(() => {
+        const currentIndex = filteredTabs.findIndex(t => t.value === selectedTab)
+        if (currentIndex >= 0 && currentIndex < filteredTabs.length - 1) {
+            const nextTab = filteredTabs[currentIndex + 1]
+            setEnabledTabs((prev) => {
+                if (!prev.includes(nextTab.value)) {
+                    return [...prev, nextTab.value]
+                }
+                return prev
+            })
+            handleSetSelectedTab(nextTab.value)
+        }
+    }, [selectedTab, handleSetSelectedTab, filteredTabs])
+
+    const enablePreviousTab = useCallback(() => {
+        const currentIndex = filteredTabs.findIndex(t => t.value === selectedTab)
+        if (currentIndex > 0) {
+            const prevTab = filteredTabs[currentIndex - 1]
+            setEnabledTabs((prev) => {
+                if (!prev.includes(prevTab.value)) {
+                    return [...prev, prevTab.value]
+                }
+                return prev
+            })
+            handleSetSelectedTab(prevTab.value)
+        }
+    }, [selectedTab, handleSetSelectedTab, filteredTabs])
+
+    const enableAllTabs = useCallback(() => {
+        setEnabledTabs(filteredTabs.map(t => t.value))
+    }, [filteredTabs])
+
+    const tabsWithEnabled = filteredTabs.map(tab => ({
+        ...tab,
+        enabled: enabledTabs.includes(tab.value),
+    }))
+
+    return (
+        <SimStudioTabContext.Provider value={{
+            selectedTab,
+            enabledTabs,
+            tabs: tabsWithEnabled,
+            setSelectedTab: handleSetSelectedTab,
+            enableNextTab,
+            enableAllTabs,
+            enablePreviousTab,
+        }}>
+            {children}
+        </SimStudioTabContext.Provider>
+    )
+}

--- a/frontend/src/contexts/SimStudioTabContext/index.tsx
+++ b/frontend/src/contexts/SimStudioTabContext/index.tsx
@@ -1,0 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
+export { SimStudioTabProvider } from './SimStudioTabProvider'
+export { useSimStudioTab } from './useSimStudioTab'
+export { SimStudioTabContext, type SimStudioTabContextType } from './SimStudioTabContext'

--- a/frontend/src/contexts/SimStudioTabContext/useSimStudioTab.ts
+++ b/frontend/src/contexts/SimStudioTabContext/useSimStudioTab.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react"
+import { SimStudioTabContext, type SimStudioTabContextType } from "./SimStudioTabContext"
+
+export const useSimStudioTab = (): SimStudioTabContextType => {
+    const context = useContext(SimStudioTabContext)
+    if (!context) {
+        throw new Error("useSimStudioTab must be used within a SimStudioTabProvider")
+    }
+    return context
+}

--- a/frontend/src/hooks/SimStudio/useCreateSimSuiteController.tsx
+++ b/frontend/src/hooks/SimStudio/useCreateSimSuiteController.tsx
@@ -1,0 +1,214 @@
+import { yupResolver } from "@hookform/resolvers/yup";
+import { useCallback, useEffect, useMemo } from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+import * as yup from "yup";
+import type { DropdownOption } from "../../components/DropDown";
+import { useSimStudioTab } from "../../contexts/SimStudioTabContext";
+import { useGetTypesQuery, useLazyGetTxtpVersionsQuery } from "../../redux/Api/Config";
+import { LocalStorage } from "../../utils/Common/enums";
+import { extractData, insertData } from "../../utils/Common/storage";
+import { SimStudioTabs } from "../../utils/Constants/data";
+import PlaceholderStep from "../../components/SimStudio/PlaceholderStep";
+import Step1RuleDetails from "../../components/SimStudio/RuleDetails";
+import TxtpSelection from "../../components/SimStudio/TxtpSelection";
+
+export interface Step1Values {
+    suite_name: string;
+    description: string;
+    associated_rule: DropdownOption | null;
+    rule_version: DropdownOption | null;
+    txtp: DropdownOption | null;
+    version: DropdownOption | null;
+}
+
+export interface SimData {
+    step1?: Step1Values;
+}
+
+const step1Schema = yup.object({
+    suite_name: yup
+        .string()
+        .required("Suite name is required")
+        .min(3, "Minimum 3 characters"),
+    description: yup.string().default(""),
+    associated_rule: yup
+        .object({ label: yup.string().required(), value: yup.mixed().required() })
+        .nullable()
+        .optional(),
+    rule_version: yup
+        .object({ label: yup.string().required(), value: yup.mixed().required() })
+        .nullable()
+        .test("required-if-rule", "Rule version is required", function (val) {
+            const { associated_rule } = this.parent as Step1Values;
+            if (associated_rule?.value) return val !== null && val !== undefined;
+            return true;
+        }),
+    txtp: yup
+        .object({ label: yup.string().required(), value: yup.mixed().required() })
+        .nullable()
+        .test("not-null", "TXTP is required", (val) => val !== null && val !== undefined),
+    version: yup
+        .object({ label: yup.string().required(), value: yup.mixed().required() })
+        .nullable()
+        .test("not-null", "Version is required", (val) => val !== null && val !== undefined),
+});
+
+const MOCK_RULES: DropdownOption[] = [
+    { label: "Rule 001", value: "Rule 001" },
+    { label: "Rule 002", value: "Rule 002" },
+    { label: "Rule 003", value: "Rule 003" },
+    { label: "Rule 004", value: "Rule 004" },
+    { label: "Rule 005", value: "Rule 005" },
+];
+
+const MOCK_RULE_VERSIONS: Record<string, DropdownOption[]> = {
+    "Rule 001": [{ label: "v1.0", value: "v1.0" }, { label: "v1.1", value: "v1.1" }, { label: "v2.0", value: "v2.0" }],
+    "Rule 002": [{ label: "v1.0", value: "v1.0" }],
+    "Rule 003": [{ label: "v1.0", value: "v1.0" }, { label: "v2.0", value: "v2.0" }],
+    "Rule 004": [{ label: "v1.0", value: "v1.0" }, { label: "v1.1", value: "v1.1" }],
+    "Rule 005": [{ label: "v1.0", value: "v1.0" }, { label: "v1.1", value: "v1.1" }, { label: "v2.0", value: "v2.0" }],
+};
+
+const SIM_DATA_KEY = 'sim_data';
+
+const readSimData = (): SimData => {
+    try {
+        return (extractData(SIM_DATA_KEY, LocalStorage, false) as SimData) ?? {};
+    } catch {
+        return {};
+    }
+};
+
+const writeSimData = (patch: Partial<SimData>) => {
+    const existing = readSimData();
+    insertData({ ...existing, ...patch }, SIM_DATA_KEY, LocalStorage, false);
+};
+
+const useCreateSimSuiteController = () => {
+    const navigate = useNavigate();
+    const { selectedTab, tabs, enableNextTab, enablePreviousTab } = useSimStudioTab();
+
+    useEffect(() => {
+        localStorage.removeItem(SIM_DATA_KEY);
+    }, []);
+
+    const {
+        control,
+        handleSubmit,
+        watch,
+        setValue,
+        formState: { errors },
+    } = useForm<Step1Values>({
+        resolver: yupResolver(step1Schema) as never,
+        defaultValues: {
+            suite_name: "",
+            description: "",
+            associated_rule: null,
+            rule_version: null,
+            txtp: null,
+            version: null,
+        },
+    });
+
+    const selectedTxtp = watch("txtp");
+    const selectedRule = watch("associated_rule");
+
+    const { data: txTypesData, isLoading: txLoading } = useGetTypesQuery({});
+
+    const txTypeOptions = useMemo<DropdownOption[]>(() => {
+        if (!txTypesData || !Array.isArray(txTypesData)) return [];
+        const seen = new Set<string>();
+        return (txTypesData as { transaction_type: string }[]).reduce<DropdownOption[]>((acc, item) => {
+            if (!seen.has(item.transaction_type)) {
+                seen.add(item.transaction_type);
+                acc.push({ label: item.transaction_type, value: item.transaction_type });
+            }
+            return acc;
+        }, []);
+    }, [txTypesData]);
+
+    const [getVersions, { data: versionsData, isFetching: versionLoading }] =
+        useLazyGetTxtpVersionsQuery();
+
+    const fetchVersions = useCallback(
+        (type: string) => { void getVersions({ type }); },
+        [getVersions]
+    );
+
+    useEffect(() => {
+        if (selectedTxtp?.value) {
+            fetchVersions(String(selectedTxtp.value));
+            setValue("version", null);
+        } else {
+            setValue("version", null);
+        }
+    }, [selectedTxtp, fetchVersions, setValue]);
+
+    const versionOptions = useMemo<DropdownOption[]>(() => {
+        if (!versionsData || !Array.isArray(versionsData)) return [];
+        return (versionsData as string[]).map((v) => ({ label: v, value: v }));
+    }, [versionsData]);
+
+    useEffect(() => {
+        setValue("rule_version", null);
+    }, [selectedRule, setValue]);
+
+    const ruleVersionOptions = useMemo<DropdownOption[]>(() => {
+        const key = String(selectedRule?.value ?? "");
+        return MOCK_RULE_VERSIONS[key] ?? [];
+    }, [selectedRule]);
+
+    const handleBack = () => {
+        if (selectedTab === SimStudioTabs[0].value) {
+            navigate("/sim-studio");
+        } else {
+            enablePreviousTab();
+        }
+    };
+
+    const handleNextStep = () => {
+        if (selectedTab === SimStudioTabs[0].value) {
+            void handleSubmit((data) => {
+                writeSimData({ step1: data });
+                enableNextTab();
+            })();
+        } else {
+            enableNextTab();
+        }
+    };
+
+    const renderStep = () => {
+        switch (selectedTab) {
+            case 'rule_details':
+                return (
+                    <Step1RuleDetails
+                        control={control}
+                        errors={errors}
+                        txTypeOptions={txTypeOptions}
+                        versionOptions={versionOptions}
+                        ruleOptions={MOCK_RULES}
+                        ruleVersionOptions={ruleVersionOptions}
+                        txLoading={txLoading}
+                        versionLoading={versionLoading}
+                    />
+                );
+            case 'txtp_selection':      return <TxtpSelection />;
+            case 'trigger_data':        return <PlaceholderStep title="Trigger Data" />;
+            case 'enrichment_data':     return <PlaceholderStep title="Enrichment Data" />;
+            case 'preview_save':        return <PlaceholderStep title="Preview & Save" />;
+            case 'simulation_results':  return <PlaceholderStep title="Simulation Results" />;
+            case 'summary':             return <PlaceholderStep title="Summary" />;
+            default:                    return null;
+        }
+    };
+
+    const currentStepIndex = tabs.findIndex(t => t.value === selectedTab);
+
+    return {
+        values: { currentStepIndex, totalSteps: tabs.length },
+        functions: { handleBack, handleNextStep, renderStep },
+    };
+};
+
+export default useCreateSimSuiteController;

--- a/frontend/src/hooks/SimStudio/useTxtpSelectionController.tsx
+++ b/frontend/src/hooks/SimStudio/useTxtpSelectionController.tsx
@@ -123,9 +123,13 @@ const useTxtpSelectionController = () => {
         return (addVersionsData as string[]).map((v) => ({ label: v, value: v }));
     }, [addVersionsData]);
 
+    const handleTxtpChange = useCallback((value: DropdownOption | null) => {
+        setAddTxtp(value);
+        setAddVersion(null);
+    }, []);
+
     useEffect(() => {
         if (addTxtp?.value) {
-            setAddVersion(null);
             void fetchVersionsForAdd({ type: String(addTxtp.value) });
         }
     }, [addTxtp, fetchVersionsForAdd]);
@@ -246,7 +250,7 @@ const useTxtpSelectionController = () => {
             adding,
         },
         functions: {
-            setAddTxtp,
+            handleTxtpChange,
             setAddVersion,
             setNumMessages,
             handleAdd,

--- a/frontend/src/hooks/SimStudio/useTxtpSelectionController.tsx
+++ b/frontend/src/hooks/SimStudio/useTxtpSelectionController.tsx
@@ -1,0 +1,292 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import toast from "react-hot-toast";
+import type { DropdownOption } from "../../components/DropDown";
+import {
+    useGetTypesQuery,
+    useLazyGetSamplePayloadQuery,
+    useLazyGetTxtpVersionsQuery,
+} from "../../redux/Api/Config";
+import { LocalStorage } from "../../utils/Common/enums";
+import { extractData, insertData } from "../../utils/Common/storage";
+
+export type FieldAction = "sample" | "static" | "range" | "skip";
+
+export interface FieldConfig {
+    action: FieldAction;
+    staticValue: string;
+    rangeStart: string;
+    rangeEnd: string;
+}
+
+export interface TxtpEntry {
+    id: string;
+    txtp: string;
+    version: string;
+    numMessages: number;
+    expanded: boolean;
+    payload: Record<string, unknown> | null;
+    fieldPaths: string[];
+    fieldConfigs: Record<string, FieldConfig>;
+    schemaLoaded: boolean;
+    sampleAvailable: boolean;
+}
+
+export interface SimFieldConfig {
+    action: "sample" | "static" | "range" | "skip";
+    static_value: string | null;
+    range_start: string | null;
+    range_end: string | null;
+}
+
+export interface SimTxtpPayload {
+    txtp: string;
+    version: string;
+    num_messages: number;
+    is_primary: boolean;
+    field_configs: Record<string, SimFieldConfig>;
+}
+
+export interface SimCreationPayload {
+    suite_name: string;
+    description: string;
+    associated_rule: string | null;
+    rule_version: string | null;
+    txtp_list: SimTxtpPayload[];
+}
+
+const flattenPaths = (obj: unknown, prefix = ""): string[] => {
+    if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
+        return prefix ? [prefix] : [];
+    }
+    return Object.entries(obj as Record<string, unknown>).flatMap(([key, val]) => {
+        const path = prefix ? `${prefix}.${key}` : key;
+        if (typeof val === "object" && val !== null && !Array.isArray(val)) {
+            return flattenPaths(val, path);
+        }
+        return [path];
+    });
+};
+
+const SIM_DATA_KEY = "sim_data";
+
+const readSimData = () => {
+    try {
+        return (extractData(SIM_DATA_KEY, LocalStorage, false) as Record<string, unknown>) ?? {};
+    } catch {
+        return {} as Record<string, unknown>;
+    }
+};
+
+const writeStep2 = (entries: TxtpEntry[]) => {
+    const existing = readSimData();
+    const step2 = entries.map((e) => ({
+        id: e.id,
+        txtp: e.txtp,
+        version: e.version,
+        numMessages: e.numMessages,
+        fieldConfigs: e.fieldConfigs,
+    }));
+    insertData({ ...existing, step2 }, SIM_DATA_KEY, LocalStorage, false);
+};
+
+const useTxtpSelectionController = () => {
+    const initialized = useRef(false);
+
+    const [entries, setEntries] = useState<TxtpEntry[]>([]);
+    const [adding, setAdding] = useState(false);
+    const [addTxtp, setAddTxtp] = useState<DropdownOption | null>(null);
+    const [addVersion, setAddVersion] = useState<DropdownOption | null>(null);
+    const [numMessages, setNumMessages] = useState<number>(100);
+
+    const { data: txTypesData } = useGetTypesQuery({});
+    const [fetchVersionsForAdd, { data: addVersionsData, isFetching: addVersionsLoading }] =
+        useLazyGetTxtpVersionsQuery();
+    const [getPayload] = useLazyGetSamplePayloadQuery();
+
+    const txTypeOptions = useMemo<DropdownOption[]>(() => {
+        if (!txTypesData || !Array.isArray(txTypesData)) return [];
+        const seen = new Set<string>();
+        return (txTypesData as { transaction_type: string }[]).reduce<DropdownOption[]>(
+            (acc, item) => {
+                if (!seen.has(item.transaction_type)) {
+                    seen.add(item.transaction_type);
+                    acc.push({ label: item.transaction_type, value: item.transaction_type });
+                }
+                return acc;
+            },
+            []
+        );
+    }, [txTypesData]);
+
+    const addVersionOptions = useMemo<DropdownOption[]>(() => {
+        if (!addVersionsData || !Array.isArray(addVersionsData)) return [];
+        return (addVersionsData as string[]).map((v) => ({ label: v, value: v }));
+    }, [addVersionsData]);
+
+    useEffect(() => {
+        if (addTxtp?.value) {
+            setAddVersion(null);
+            void fetchVersionsForAdd({ type: String(addTxtp.value) });
+        }
+    }, [addTxtp, fetchVersionsForAdd]);
+
+    const buildEntry = useCallback(
+        async (txtp: string, version: string, msgs: number): Promise<TxtpEntry> => {
+            try {
+                const payload = (await getPayload({ type: txtp, version }).unwrap()) as Record<
+                    string,
+                    unknown
+                >;
+                const fieldPaths = flattenPaths(payload);
+                return {
+                    id: `${txtp}_${version}_${Date.now()}`,
+                    txtp,
+                    version,
+                    numMessages: msgs,
+                    expanded: false,
+                    payload,
+                    fieldPaths,
+                    fieldConfigs: {},
+                    schemaLoaded: true,
+                    sampleAvailable: fieldPaths.length > 0,
+                };
+            } catch {
+                return {
+                    id: `${txtp}_${version}_${Date.now()}`,
+                    txtp,
+                    version,
+                    numMessages: msgs,
+                    expanded: false,
+                    payload: null,
+                    fieldPaths: [],
+                    fieldConfigs: {},
+                    schemaLoaded: false,
+                    sampleAvailable: false,
+                };
+            }
+        },
+        [getPayload]
+    );
+
+    useEffect(() => {
+        if (initialized.current) return;
+        initialized.current = true;
+
+        const simData = readSimData() as {
+            step1?: { txtp?: { value: string }; version?: { value: string } };
+        };
+        const txtp = simData.step1?.txtp?.value;
+        const version = simData.step1?.version?.value;
+        if (!txtp || !version) return;
+
+        void buildEntry(txtp, version, 100).then((entry) => {
+            setEntries([entry]);
+            writeStep2([entry]);
+        });
+    }, [buildEntry]);
+
+    const handleAdd = useCallback(() => {
+        if (!addTxtp?.value || !addVersion?.value) {
+            toast.error("Please select TXTP Type and Version");
+            return;
+        }
+        setAdding(true);
+        void buildEntry(String(addTxtp.value), String(addVersion.value), numMessages).then(
+            (entry) => {
+                setEntries((prev) => {
+                    const updated = [...prev, entry];
+                    writeStep2(updated);
+                    return updated;
+                });
+                setAddTxtp(null);
+                setAddVersion(null);
+                setNumMessages(100);
+                setAdding(false);
+            }
+        );
+    }, [addTxtp, addVersion, numMessages, buildEntry]);
+
+    const handleRemove = useCallback((id: string) => {
+        setEntries((prev) => {
+            const updated = prev.filter((e) => e.id !== id);
+            writeStep2(updated);
+            return updated;
+        });
+    }, []);
+
+    const handleToggleExpand = useCallback((id: string) => {
+        setEntries((prev) =>
+            prev.map((e) => (e.id === id ? { ...e, expanded: !e.expanded } : e))
+        );
+    }, []);
+
+    const handleFieldConfigChange = useCallback(
+        (entryId: string, fieldPath: string, config: FieldConfig) => {
+            setEntries((prev) => {
+                const updated = prev.map((e) => {
+                    if (e.id !== entryId) return e;
+                    return { ...e, fieldConfigs: { ...e.fieldConfigs, [fieldPath]: config } };
+                });
+                writeStep2(updated);
+                return updated;
+            });
+        },
+        []
+    );
+
+    return {
+        values: {
+            entries,
+            txTypeOptions,
+            addTxtp,
+            addVersion,
+            addVersionOptions,
+            addVersionsLoading,
+            numMessages,
+            adding,
+        },
+        functions: {
+            setAddTxtp,
+            setAddVersion,
+            setNumMessages,
+            handleAdd,
+            handleRemove,
+            handleToggleExpand,
+            handleFieldConfigChange,
+        },
+    };
+};
+
+export default useTxtpSelectionController;
+
+export const buildSimPayload = (
+    entries: TxtpEntry[],
+    step1: {
+        suite_name: string;
+        description: string;
+        associated_rule?: { label: string; value: string } | null;
+        rule_version?: { label: string; value: string } | null;
+    }
+): SimCreationPayload => ({
+    suite_name: step1.suite_name,
+    description: step1.description,
+    associated_rule: step1.associated_rule?.value ?? null,
+    rule_version: step1.rule_version?.value ?? null,
+    txtp_list: entries.map((entry, idx) => ({
+        txtp: entry.txtp,
+        version: entry.version,
+        num_messages: entry.numMessages,
+        is_primary: idx === 0,
+        field_configs: Object.fromEntries(
+            Object.entries(entry.fieldConfigs).map(([path, cfg]) => [
+                path,
+                {
+                    action: cfg.action,
+                    static_value: cfg.action === "static" ? cfg.staticValue : null,
+                    range_start: cfg.action === "range" && cfg.rangeStart ? cfg.rangeStart : null,
+                    range_end: cfg.action === "range" && cfg.rangeEnd ? cfg.rangeEnd : null,
+                },
+            ])
+        ),
+    })),
+});

--- a/frontend/src/layout/Sidebar/index.tsx
+++ b/frontend/src/layout/Sidebar/index.tsx
@@ -1,4 +1,5 @@
 import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined';
+import LayersOutlinedIcon from '@mui/icons-material/LayersOutlined';
 import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
 import { Box } from "@mui/material";
 import { useState } from "react";
@@ -14,6 +15,7 @@ const sharedMenuItems: { icon: React.ReactElement, label: string, route: string,
 ];
 
 const trsMenuItems: { icon: React.ReactElement, label: string, route: string, color: string }[] = [
+    { icon: <LayersOutlinedIcon />, label: "Sim Studio", route: "sim-studio", color: "#f59e0b" },
     { icon: <ScienceOutlinedIcon />, label: "Sandbox", route: "sandbox", color: "#2bc08f" },
 ];
 

--- a/frontend/src/pages/SimStudio/CreateSimSuite/CreateSimSuite.styles.ts
+++ b/frontend/src/pages/SimStudio/CreateSimSuite/CreateSimSuite.styles.ts
@@ -1,0 +1,114 @@
+import { Box, styled } from "@mui/material";
+
+export const PageContainer = styled(Box)(() => ({
+    minHeight: "100vh",
+    backgroundColor: "#f3f4f6",
+    display: "flex",
+    flexDirection: "column",
+}));
+
+export const TopBar = styled(Box)(({ theme }) => ({
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    padding: theme.spacing(1.5, 3),
+    backgroundColor: "#fff",
+    borderBottom: "1px solid #e5e7eb",
+}));
+
+export const StepperBar = styled(Box)(({ theme }) => ({
+    display: "flex",
+    alignItems: "flex-start",
+    justifyContent: "center",
+    padding: theme.spacing(2.5, 3),
+    backgroundColor: "#fff",
+    borderBottom: "1px solid #e5e7eb",
+    overflowX: "auto",
+}));
+
+export const StepItem = styled(Box)(() => ({
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    minWidth: 80,
+    textAlign: "center",
+}));
+
+export const StepCircle = styled(Box, {
+    shouldForwardProp: (prop) => prop !== "active" && prop !== "completed",
+})<{ active?: boolean; completed?: boolean }>(({ active, completed }) => ({
+    width: 32,
+    height: 32,
+    borderRadius: "50%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    fontSize: "13px",
+    fontWeight: 600,
+    flexShrink: 0,
+    transition: "all 0.2s",
+    backgroundColor: active || completed ? "#2b7fff" : "#fff",
+    color: active || completed ? "#fff" : "#9ca3af",
+    border: `2px solid ${active || completed ? "#2b7fff" : "#d1d5db"}`,
+}));
+
+export const StepLabel = styled(Box)(({ theme }) => ({
+    marginTop: theme.spacing(0.75),
+    fontSize: "11px",
+    color: theme.palette.text.ternary,
+    whiteSpace: "pre-line",
+    lineHeight: 1.4,
+    textAlign: "center",
+}));
+
+export const StepConnector = styled(Box)(() => ({
+    fontSize: "16px",
+    color: "#d1d5db",
+    display: "flex",
+    alignItems: "flex-start",
+    paddingTop: "6px",
+    paddingLeft: "4px",
+    paddingRight: "4px",
+    flexShrink: 0,
+}));
+
+export const ContentArea = styled(Box)(({ theme }) => ({
+    flex: 1,
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    padding: theme.spacing(4, 3),
+}));
+
+export const FormCard = styled(Box)(({ theme }) => ({
+    backgroundColor: "#fff",
+    border: "1px solid #e5e7eb",
+    borderRadius: "8px",
+    padding: theme.spacing(3),
+    width: "100%",
+    maxWidth: "700px",
+}));
+
+export const InfoBanner = styled(Box)(({ theme }) => ({
+    display: "flex",
+    alignItems: "flex-start",
+    gap: theme.spacing(1.25),
+    padding: theme.spacing(1.5, 2),
+    backgroundColor: "#eff6ff",
+    border: "1px solid #bfdbfe",
+    borderRadius: "6px",
+    marginBottom: theme.spacing(2.5),
+    width: "100%",
+    maxWidth: "700px",
+}));
+
+export const BottomBar = styled(Box)(({ theme }) => ({
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    padding: theme.spacing(2, 3),
+    backgroundColor: "#fff",
+    borderTop: "1px solid #e5e7eb",
+    position: "sticky",
+    bottom: 0,
+}));

--- a/frontend/src/pages/SimStudio/CreateSimSuite/index.tsx
+++ b/frontend/src/pages/SimStudio/CreateSimSuite/index.tsx
@@ -1,0 +1,82 @@
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import { Box, Button, IconButton } from "@mui/material";
+import Tabs from "../../../components/Tabs";
+import { Text } from "../../../components/Text";
+import { SimStudioTabProvider } from "../../../contexts/SimStudioTabContext";
+import { useSimStudioTab } from "../../../contexts/SimStudioTabContext";
+import * as S from "./CreateSimSuite.styles";
+import useCreateSimSuiteController from "../../../hooks/SimStudio/useCreateSimSuiteController";
+
+const CreateSimSuiteContent = () => {
+    const { values, functions } = useCreateSimSuiteController();
+    const { tabs } = useSimStudioTab();
+
+    return (
+        <S.PageContainer>
+            <S.TopBar>
+                <Box display="flex" alignItems="center" gap={1}>
+                    <IconButton
+                        size="small"
+                        onClick={functions.handleBack}
+                        sx={{ color: "text.primary" }}
+                    >
+                        <ArrowBackIcon fontSize="small" />
+                    </IconButton>
+                    <Text weight="bold" color="black" size="header">
+                        Create Simulation Suite
+                    </Text>
+                </Box>
+                <Text color="text.ternary" size="sub">
+                    Step {values.currentStepIndex + 1} of {tabs.length}
+                </Text>
+            </S.TopBar>
+            <Box sx={{ backgroundColor: "#fff", borderBottom: "1px solid #e5e7eb", px: 3 }}>
+                <Tabs variant="sim-studio" />
+            </Box>
+            <S.ContentArea>{functions.renderStep()}</S.ContentArea>
+            <S.BottomBar>
+                <Button
+                    variant="outlined"
+                    onClick={functions.handleBack}
+                    sx={{
+                        textTransform: "none",
+                        height: "38px",
+                        px: 3,
+                        borderColor: "#dfddde",
+                        color: "#1f2937",
+                        borderRadius: "6px",
+                        "&:hover": { borderColor: "#b0b0b0", backgroundColor: "#f9fafb" },
+                    }}
+                >
+                    Back
+                </Button>
+                <Button
+                    variant="contained"
+                    endIcon={<ChevronRightIcon />}
+                    onClick={functions.handleNextStep}
+                    sx={{
+                        textTransform: "none",
+                        height: "38px",
+                        px: 3,
+                        borderRadius: "6px",
+                        backgroundColor: "#2b7fff",
+                        "&:hover": { backgroundColor: "#1a6fee" },
+                        boxShadow: "none",
+                        color: "#fff",
+                    }}
+                >
+                    Next Step
+                </Button>
+            </S.BottomBar>
+        </S.PageContainer>
+    );
+};
+
+const CreateSimSuite = () => (
+    <SimStudioTabProvider>
+        <CreateSimSuiteContent />
+    </SimStudioTabProvider>
+);
+
+export default CreateSimSuite;

--- a/frontend/src/pages/SimStudio/SimStudio.styles.ts
+++ b/frontend/src/pages/SimStudio/SimStudio.styles.ts
@@ -1,0 +1,94 @@
+import { Box, styled } from "@mui/material";
+
+export const StatCard = styled(Box)(({ theme }) => ({
+    display: "flex",
+    alignItems: "center",
+    gap: theme.spacing(2),
+    padding: theme.spacing(2, 2.5),
+    borderRadius: "8px",
+    border: `1px solid ${theme.palette.static.border}`,
+    backgroundColor: "#fff",
+    flex: 1,
+    minWidth: 0,
+}));
+
+export const StatIconWrapper = styled(Box, {
+    shouldForwardProp: (prop) => prop !== "iconColor",
+})<{ iconColor: string }>(({ iconColor }) => ({
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    width: "42px",
+    height: "42px",
+    borderRadius: "50%",
+    backgroundColor: `${iconColor}1a`,
+    color: iconColor,
+    flexShrink: 0,
+}));
+
+export const StatsRow = styled(Box)(({ theme }) => ({
+    display: "flex",
+    gap: theme.spacing(2),
+    marginTop: theme.spacing(2),
+    [theme.breakpoints.down("sm")]: {
+        flexWrap: "wrap",
+    },
+}));
+
+export const FiltersRow = styled(Box)(({ theme }) => ({
+    display: "flex",
+    alignItems: "center",
+    gap: theme.spacing(1.5),
+    marginTop: theme.spacing(3),
+    flexWrap: "wrap",
+}));
+
+export const TxtpBadge = styled(Box)(({ theme }) => ({
+    display: "inline-flex",
+    alignItems: "center",
+    padding: "2px 10px",
+    borderRadius: "4px",
+    backgroundColor: theme.palette.static.lightGrey,
+    border: `1px solid ${theme.palette.static.border}`,
+    fontSize: "12px",
+    fontWeight: 500,
+    color: theme.palette.text.primary,
+    fontFamily: "monospace",
+    userSelect: "none",
+}));
+
+export const RuleLink = styled(Box)(({ theme }) => ({
+    color: theme.palette.text.secondary,
+    cursor: "pointer",
+    fontSize: "14px",
+    "&:hover": {
+        textDecoration: "underline",
+    },
+}));
+
+export const selectSx = {
+    minWidth: 160,
+    borderRadius: "6px",
+    "& .MuiOutlinedInput-notchedOutline": {
+        borderColor: "#dfddde",
+    },
+    "&:hover .MuiOutlinedInput-notchedOutline": {
+        borderColor: "#b0b0b0",
+    },
+    "& .MuiSelect-select": {
+        paddingTop: "8.5px",
+        paddingBottom: "8.5px",
+        fontSize: "14px",
+    },
+} as const;
+
+export const activeSelectSx = {
+    ...selectSx,
+    "& .MuiOutlinedInput-notchedOutline": {
+        borderColor: "#4789f6",
+        borderWidth: "1.5px",
+    },
+    "&:hover .MuiOutlinedInput-notchedOutline": {
+        borderColor: "#4789f6",
+    },
+} as const;

--- a/frontend/src/pages/SimStudio/SimStudioActions.tsx
+++ b/frontend/src/pages/SimStudio/SimStudioActions.tsx
@@ -1,0 +1,19 @@
+import VisibilityOutlinedIcon from "@mui/icons-material/VisibilityOutlined";
+import { IconButton, Tooltip } from "@mui/material";
+import { memo } from "react";
+
+interface SimStudioActionsProps {
+    onView: () => void;
+}
+
+const SimStudioActions = ({ onView }: SimStudioActionsProps) => {
+    return (
+        <Tooltip title="View">
+            <IconButton size="small" sx={{ color: "text.ternary" }} onClick={onView}>
+                <VisibilityOutlinedIcon fontSize="small" />
+            </IconButton>
+        </Tooltip>
+    );
+};
+
+export default memo(SimStudioActions);

--- a/frontend/src/pages/SimStudio/index.tsx
+++ b/frontend/src/pages/SimStudio/index.tsx
@@ -1,0 +1,284 @@
+import AddIcon from "@mui/icons-material/Add";
+import AccessTimeOutlinedIcon from "@mui/icons-material/AccessTimeOutlined";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import CloseIcon from "@mui/icons-material/Close";
+import DraftsOutlinedIcon from "@mui/icons-material/DraftsOutlined";
+import FilterAltOffIcon from "@mui/icons-material/FilterAltOff";
+import FilterListIcon from "@mui/icons-material/FilterList";
+import LayersOutlinedIcon from "@mui/icons-material/LayersOutlined";
+import SearchIcon from "@mui/icons-material/Search";
+import StorageOutlinedIcon from "@mui/icons-material/StorageOutlined";
+import {
+    Box,
+    Divider,
+    IconButton,
+    InputAdornment,
+    MenuItem,
+    Popover,
+    Select,
+    TextField,
+    Typography,
+} from "@mui/material";
+import { useState, type MouseEvent } from "react";
+import Button from "../../components/Button";
+import Table from "../../components/Table";
+import { Text } from "../../components/Text";
+import BoxWrapper from "../../components/Wrappers/BoxWrapper";
+import * as S from "./SimStudio.styles";
+import useSimStudioController from "./useSimStudioController";
+
+const STAT_CONFIG = [
+    {
+        key: "total" as const,
+        label: "Total Suites",
+        Icon: StorageOutlinedIcon,
+        iconColor: "#4789f6",
+    },
+    {
+        key: "readyForSimulation" as const,
+        label: "Ready for Simulation",
+        Icon: CheckCircleOutlineIcon,
+        iconColor: "#00a63e",
+    },
+    {
+        key: "drafts" as const,
+        label: "Draft Suites",
+        Icon: DraftsOutlinedIcon,
+        iconColor: "#f59e0b",
+    },
+    {
+        key: "latestIteration" as const,
+        label: "Latest Iteration",
+        Icon: AccessTimeOutlinedIcon,
+        iconColor: "#8b5cf6",
+    },
+] as const;
+
+const SimStudio = () => {
+    const { values, functions } = useSimStudioController();
+    const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+    const handleOpenFilters = (e: MouseEvent<HTMLElement>) => setAnchorEl(e.currentTarget);
+    const handleCloseFilters = () => setAnchorEl(null);
+    const isFiltersOpen = Boolean(anchorEl);
+
+    return (
+        <BoxWrapper>
+            <Box display="flex" alignItems="center" justifyContent="space-between" gap={2}>
+                <Box display="flex" alignItems="center" gap={1.5} minWidth={0}>
+                    <LayersOutlinedIcon sx={{ color: "#4789f6", fontSize: 30, flexShrink: 0 }} />
+                    <Box minWidth={0}>
+                        <Text weight="bold" color="black" size="header">
+                            Message Sampler
+                        </Text>
+                        <Text color="text.ternary" size="sub">
+                            Create and manage synthetic simulation suites for rule testing.
+                        </Text>
+                    </Box>
+                </Box>
+                <Button
+                    Icon={AddIcon}
+                    height="40px"
+                    type="secondary"
+                    size=""
+                    text="Create Simulation Suite"
+                    onClick={functions.handleCreate}
+                />
+            </Box>
+            <S.StatsRow>
+                {STAT_CONFIG.map(({ key, label, Icon, iconColor }) => (
+                    <S.StatCard key={key}>
+                        <S.StatIconWrapper iconColor={iconColor}>
+                            <Icon fontSize="small" />
+                        </S.StatIconWrapper>
+                        <Box minWidth={0}>
+                            <Text size="sub" color="text.ternary">
+                                {label}
+                            </Text>
+                            <Text size="header" weight="bold" color="black">
+                                {values.stats[key]}
+                            </Text>
+                        </Box>
+                    </S.StatCard>
+                ))}
+            </S.StatsRow>
+            <S.FiltersRow>
+                <TextField
+                    size="small"
+                    placeholder="Search by suite name..."
+                    value={values.searchInput}
+                    onChange={(e) => functions.handleSearch(e.target.value)}
+                    InputProps={{
+                        startAdornment: (
+                            <InputAdornment position="start">
+                                <SearchIcon sx={{ color: "text.ternary", fontSize: 18 }} />
+                            </InputAdornment>
+                        ),
+                    }}
+                    sx={{
+                        flex: 1,
+                        maxWidth: 340,
+                        "& .MuiOutlinedInput-root": {
+                            borderRadius: "6px",
+                            "& fieldset": { borderColor: "#dfddde" },
+                            "&:hover fieldset": { borderColor: "#b0b0b0" },
+                        },
+                    }}
+                />
+
+                <Select
+                    size="small"
+                    value={values.statusFilter}
+                    onChange={(e) => functions.handleStatusFilter(e.target.value)}
+                    displayEmpty
+                    sx={S.selectSx}
+                >
+                    <MenuItem value="">All Statuses</MenuItem>
+                    <MenuItem value="Ready for Simulation">Ready for Simulation</MenuItem>
+                    <MenuItem value="Draft">Draft</MenuItem>
+                    <MenuItem value="Generated">Generated</MenuItem>
+                </Select>
+                <Select
+                    size="small"
+                    value={values.ruleFilter}
+                    onChange={(e) => functions.handleRuleFilter(e.target.value)}
+                    displayEmpty
+                    sx={values.ruleFilter ? S.activeSelectSx : S.selectSx}
+                >
+                    <MenuItem value="">All Rules</MenuItem>
+                    {values.availableRules.map((rule) => (
+                        <MenuItem key={rule} value={rule}>
+                            {rule}
+                        </MenuItem>
+                    ))}
+                </Select>
+                <Button
+                    Icon={FilterListIcon}
+                    height="36px"
+                    type="secondary"
+                    size=""
+                    text="More Filters"
+                    onClick={handleOpenFilters}
+                />
+
+                {values.hasAnyFilter && (
+                    <IconButton
+                        title="Reset Filters"
+                        onClick={functions.handleResetAllFilters}
+                        size="small"
+                    >
+                        <FilterAltOffIcon
+                            sx={{
+                                width: "25px",
+                                height: "25px",
+                                color: "text.ternary",
+                                "&:hover": { color: "error.main" },
+                            }}
+                        />
+                    </IconButton>
+                )}
+            </S.FiltersRow>
+            <Popover
+                open={isFiltersOpen}
+                anchorEl={anchorEl}
+                onClose={handleCloseFilters}
+                anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+                transformOrigin={{ vertical: "top", horizontal: "left" }}
+                slotProps={{
+                    paper: {
+                        sx: {
+                            mt: 0.5,
+                            width: 300,
+                            borderRadius: "8px",
+                            border: "1px solid #dfddde",
+                            boxShadow: "0 4px 16px rgba(0,0,0,0.10)",
+                        },
+                    },
+                }}
+            >
+                <Box
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="space-between"
+                    px={2}
+                    py={1.5}
+                >
+                    <Typography fontWeight={600} fontSize={14} color="text.primary">
+                        Advanced Filters
+                    </Typography>
+                    <IconButton size="small" onClick={handleCloseFilters}>
+                        <CloseIcon fontSize="small" />
+                    </IconButton>
+                </Box>
+
+                <Divider />
+
+                <Box px={2} py={2} display="flex" flexDirection="column" gap={2}>
+                    <Box>
+                        <Typography fontSize={12} fontWeight={500} color="text.secondary" mb={0.75}>
+                            TXTP Type
+                        </Typography>
+                        <Select
+                            size="small"
+                            fullWidth
+                            value={values.txtpFilter}
+                            onChange={(e) => functions.handleTxtpFilter(e.target.value)}
+                            displayEmpty
+                            sx={{ ...S.selectSx, minWidth: "unset" }}
+                        >
+                            <MenuItem value="">All TXTPs</MenuItem>
+                            {values.availableTxtps.map((txtp) => (
+                                <MenuItem key={txtp} value={txtp}>
+                                    {txtp}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </Box>
+                    <Box>
+                        <Typography fontSize={12} fontWeight={500} color="text.secondary" mb={0.75}>
+                            Last Updated From
+                        </Typography>
+                        <TextField
+                            type="date"
+                            size="small"
+                            fullWidth
+                            value={values.lastUpdatedFrom}
+                            onChange={(e) => functions.handleLastUpdatedFrom(e.target.value)}
+                            sx={{
+                                "& .MuiOutlinedInput-root": {
+                                    borderRadius: "6px",
+                                    "& fieldset": { borderColor: "#dfddde" },
+                                },
+                            }}
+                        />
+                    </Box>
+                    <Box>
+                        <Typography fontSize={12} fontWeight={500} color="text.secondary" mb={0.75}>
+                            Last Updated To
+                        </Typography>
+                        <TextField
+                            type="date"
+                            size="small"
+                            fullWidth
+                            value={values.lastUpdatedTo}
+                            onChange={(e) => functions.handleLastUpdatedTo(e.target.value)}
+                            sx={{
+                                "& .MuiOutlinedInput-root": {
+                                    borderRadius: "6px",
+                                    "& fieldset": { borderColor: "#dfddde" },
+                                },
+                            }}
+                        />
+                    </Box>
+                </Box>
+            </Popover>
+            <Table
+                columns={values.columns}
+                data={values.filteredData as unknown as Record<string, unknown>[]}
+                loading={values.isLoading}
+            />
+        </BoxWrapper>
+    );
+};
+
+export default SimStudio;

--- a/frontend/src/pages/SimStudio/useSimStudioController.tsx
+++ b/frontend/src/pages/SimStudio/useSimStudioController.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import StatusCard from "../../components/Cards/StatusCard";
 import type { TableColumn } from "../../components/Table";
@@ -141,6 +141,10 @@ const useSimStudioController = () => {
         setLastUpdatedTo("");
     };
 
+    const handleView = useCallback((row: Record<string, unknown>) => {
+        navigate(`/sim-studio/view/${row.id}`);
+    }, [navigate]);
+
     const columns: TableColumn[] = useMemo(() => [
         {
             label: "Suite Name",
@@ -174,11 +178,7 @@ const useSimStudioController = () => {
                 <SimStudioActions onView={() => handleView(row)} />
             ),
         },
-    ], []);
-
-    const handleView = (row: Record<string, unknown>) => {
-        navigate(`/sim-studio/view/${row.id}`);
-    };
+    ], [handleView]);
 
     const handleCreate = () => {
         navigate("/sim-studio/create");

--- a/frontend/src/pages/SimStudio/useSimStudioController.tsx
+++ b/frontend/src/pages/SimStudio/useSimStudioController.tsx
@@ -1,0 +1,218 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import StatusCard from "../../components/Cards/StatusCard";
+import type { TableColumn } from "../../components/Table";
+import useDebouncedSearch from "../../hooks/useDebouncedSearch";
+import * as S from "./SimStudio.styles";
+import SimStudioActions from "./SimStudioActions";
+
+export type SimSuiteStatus = "Ready for Simulation" | "Draft" | "Generated";
+
+export interface SimSuite {
+    id: string;
+    suite_name: string;
+    associated_rule: string;
+    txtp: string;
+    status: SimSuiteStatus;
+    iterations: number;
+    last_updated: string;
+}
+
+const MOCK_DATA: SimSuite[] = [
+    {
+        id: "1",
+        suite_name: "High Value Txns - Q3",
+        associated_rule: "Rule 001",
+        txtp: "pacs.008",
+        status: "Ready for Simulation",
+        iterations: 3,
+        last_updated: "2023-10-24",
+    },
+    {
+        id: "2",
+        suite_name: "Velocity Edge Cases",
+        associated_rule: "Rule 002",
+        txtp: "pacs.002",
+        status: "Draft",
+        iterations: 0,
+        last_updated: "2023-10-25",
+    },
+    {
+        id: "3",
+        suite_name: "Cross-border Anomalies",
+        associated_rule: "Rule 003",
+        txtp: "pain.001",
+        status: "Generated",
+        iterations: 1,
+        last_updated: "2026-05-21",
+    },
+    {
+        id: "4",
+        suite_name: "Duplicate Transaction Sweep",
+        associated_rule: "Rule 001",
+        txtp: "pacs.008",
+        status: "Ready for Simulation",
+        iterations: 2,
+        last_updated: "2023-10-20",
+    },
+    {
+        id: "5",
+        suite_name: "Rapid Transfer Burst",
+        associated_rule: "Rule 004",
+        txtp: "pain.001",
+        status: "Draft",
+        iterations: 0,
+        last_updated: "2023-10-22",
+    },
+    {
+        id: "6",
+        suite_name: "Offshore Routing Test",
+        associated_rule: "Rule 005",
+        txtp: "pacs.002",
+        status: "Generated",
+        iterations: 4,
+        last_updated: "2023-10-18",
+    },
+];
+
+const AVAILABLE_RULES = [...new Set(MOCK_DATA.map((d) => d.associated_rule))];
+const AVAILABLE_TXTPS = [...new Set(MOCK_DATA.map((d) => d.txtp))];
+
+const computeLatestIteration = (data: SimSuite[]): string => {
+    if (data.length === 0) return "—";
+    const latest = data.reduce((acc, curr) =>
+        new Date(curr.last_updated) > new Date(acc.last_updated) ? curr : acc
+    );
+    const latestDate = new Date(latest.last_updated);
+    const today = new Date();
+    if (latestDate.toDateString() === today.toDateString()) return "Today";
+    return latestDate.toLocaleDateString("en-GB", { day: "2-digit", month: "short" });
+};
+
+const useSimStudioController = () => {
+    const navigate = useNavigate();
+    const [searchInput, debouncedSearch, handleSearch] = useDebouncedSearch("", 300);
+    const [statusFilter, setStatusFilter] = useState<string>("");
+    const [ruleFilter, setRuleFilter] = useState<string>("");
+    const [txtpFilter, setTxtpFilter] = useState<string>("");
+    const [lastUpdatedFrom, setLastUpdatedFrom] = useState<string>("");
+    const [lastUpdatedTo, setLastUpdatedTo] = useState<string>("");
+
+    const stats = useMemo(() => ({
+        total: MOCK_DATA.length,
+        readyForSimulation: MOCK_DATA.filter((d) => d.status === "Ready for Simulation").length,
+        drafts: MOCK_DATA.filter((d) => d.status === "Draft").length,
+        latestIteration: computeLatestIteration(MOCK_DATA),
+    }), []);
+
+    const filteredData = useMemo(() => {
+        return MOCK_DATA.filter((suite) => {
+            const matchesSearch =
+                debouncedSearch.trim() === "" ||
+                suite.suite_name.toLowerCase().includes(debouncedSearch.toLowerCase());
+            const matchesStatus = statusFilter === "" || suite.status === statusFilter;
+            const matchesRule = ruleFilter === "" || suite.associated_rule === ruleFilter;
+            const matchesTxtp = txtpFilter === "" || suite.txtp === txtpFilter;
+            const matchesFrom = lastUpdatedFrom === "" || suite.last_updated >= lastUpdatedFrom;
+            const matchesTo = lastUpdatedTo === "" || suite.last_updated <= lastUpdatedTo;
+            return matchesSearch && matchesStatus && matchesRule && matchesTxtp && matchesFrom && matchesTo;
+        });
+    }, [debouncedSearch, statusFilter, ruleFilter, txtpFilter, lastUpdatedFrom, lastUpdatedTo]);
+
+    const hasAdvancedFilters = txtpFilter !== "" || lastUpdatedFrom !== "" || lastUpdatedTo !== "";
+    const hasAnyFilter =
+        searchInput.trim() !== "" ||
+        statusFilter !== "" ||
+        ruleFilter !== "" ||
+        hasAdvancedFilters;
+
+    const handleResetAdvancedFilters = () => {
+        setTxtpFilter("");
+        setLastUpdatedFrom("");
+        setLastUpdatedTo("");
+    };
+
+    const handleResetAllFilters = () => {
+        handleSearch("");
+        setStatusFilter("");
+        setRuleFilter("");
+        setTxtpFilter("");
+        setLastUpdatedFrom("");
+        setLastUpdatedTo("");
+    };
+
+    const columns: TableColumn[] = useMemo(() => [
+        {
+            label: "Suite Name",
+            key: "suite_name",
+            sx: { fontWeight: 600, color: "#1f2937" },
+        },
+        {
+            label: "Associated Rule",
+            key: "associated_rule",
+        },
+        {
+            label: "TXTP",
+            key: "txtp",
+            render: (row: Record<string, unknown>) => (
+                <S.TxtpBadge>{row.txtp as string}</S.TxtpBadge>
+            ),
+        },
+        {
+            label: "Status",
+            key: "status",
+            render: (row: Record<string, unknown>) => (
+                <StatusCard status={row.status as string} bullet={false} />
+            ),
+        },
+        { label: "Iterations", key: "iterations" },
+        { label: "Last Updated", key: "last_updated", type: "date" as const },
+        {
+            label: "Actions",
+            key: "actions",
+            render: (row: Record<string, unknown>) => (
+                <SimStudioActions onView={() => handleView(row)} />
+            ),
+        },
+    ], []);
+
+    const handleView = (row: Record<string, unknown>) => {
+        navigate(`/sim-studio/view/${row.id}`);
+    };
+
+    const handleCreate = () => {
+        navigate("/sim-studio/create");
+    };
+
+    return {
+        values: {
+            isLoading: false,
+            searchInput,
+            statusFilter,
+            ruleFilter,
+            txtpFilter,
+            lastUpdatedFrom,
+            lastUpdatedTo,
+            filteredData,
+            stats,
+            columns,
+            availableRules: AVAILABLE_RULES,
+            availableTxtps: AVAILABLE_TXTPS,
+            hasAdvancedFilters,
+            hasAnyFilter,
+        },
+        functions: {
+            handleSearch,
+            handleStatusFilter: setStatusFilter,
+            handleRuleFilter: setRuleFilter,
+            handleTxtpFilter: setTxtpFilter,
+            handleLastUpdatedFrom: setLastUpdatedFrom,
+            handleLastUpdatedTo: setLastUpdatedTo,
+            handleResetAdvancedFilters,
+            handleResetAllFilters,
+            handleCreate,
+        },
+    };
+};
+
+export default useSimStudioController;

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -14,6 +14,8 @@ const Simulation = lazy(() => import("../pages/Simulation"));
 const SimulationList = lazy(() => import("../pages/SimulationList"));
 const SimulationView = lazy(() => import("../pages/SimulationView"));
 const SimulationError = lazy(() => import("../pages/SimulationError"));
+const SimStudio = lazy(() => import("../pages/SimStudio"));
+const CreateSimSuite = lazy(() => import("../pages/SimStudio/CreateSimSuite"));
 
 export const ROUTES = [
     {
@@ -154,6 +156,20 @@ export const ROUTES = [
         element: <Simulation />,
         private: true,
         layout: true,
+        roleGroup: 'trs' as const,
+    },
+    {
+        path: "/sim-studio",
+        element: <SimStudio />,
+        private: true,
+        layout: true,
+        roleGroup: 'trs' as const,
+    },
+    {
+        path: "/sim-studio/create",
+        element: <CreateSimSuite />,
+        private: true,
+        layout: false,
         roleGroup: 'trs' as const,
     },
 ];

--- a/frontend/src/utils/Constants/data.ts
+++ b/frontend/src/utils/Constants/data.ts
@@ -588,6 +588,15 @@ export const SimulationTabs = [
     },
 ]
 
+export const SimStudioTabs = [
+    { label: 'Rule & Details',      value: 'rule_details',        enabled: false },
+    { label: 'TXTP Selection',      value: 'txtp_selection',      enabled: false },
+    { label: 'Trigger Data',        value: 'trigger_data',        enabled: false },
+    { label: 'Enrichment Data',     value: 'enrichment_data',     enabled: false },
+    { label: 'Preview & Save',      value: 'preview_save',        enabled: false },
+    { label: 'Simulation Results',  value: 'simulation_results',  enabled: false },
+    { label: 'Summary',             value: 'summary',             enabled: false },
+]
 
 export const claims = {
     editor: 'editor',


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Added a Simulation Studio module to the Rule Studio frontend. This includes a /sim-studio listing page with stats cards, search/filter controls, and a status table, as well as a /sim-studio/create 7-step wizard using a shared SimStudioTabContext (mirroring the Rule Editor tab pattern). Step 1 (Rule & Details) collects suite metadata via a React Hook Form + Yup validated form; Step 2 (TXTP Selection) allows users to configure one or more TXTP types — the primary entry is auto-populated from Step 1 — with per-entry field configuration tables where each payload field can be set to Use Sample Value, Set Static Value (with a free-text input), Use Range (with start/end inputs), or Skip Field. All wizard state is persisted to localStorage under the sim_data key (cleared on new suite creation), and a typed [buildSimPayload](vscode-file://vscode-app/c:/Users/MuhammadKashif/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) helper is exported to construct the synthetic-data generation API request body. Supporting infrastructure includes a SimStudio sidebar nav item, new status variants in StatusCard, proper folder structure under hooks/SimStudio/ and components/SimStudio/, and placeholder

## Why are we doing this?

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [ ] Unit tests passing and Documentation done