### PR TITLE
feat: simulation studio api integration

### DIFF
--- a/backend/src/services/simulation-studio/simulation-studio.service.ts
+++ b/backend/src/services/simulation-studio/simulation-studio.service.ts
@@ -59,7 +59,6 @@ export class SimulationStudioService {
         rule_name: suites.rule_name ?? suites.associated_rule,
         primary_txtp: suites.primary_txtp ?? suites.txtp,
         primary_txtp_version: suites.primary_txtp_version ?? suites.txtp_version ?? suites.version,
-        wizard_progress: suites.wizard_progress ?? { step: 1, completed: false },
       };
       return await this.adminServiceClient.createSimulationSuite(token, payload);
     } catch (err) {

--- a/backend/src/utils/enums/simulation.enum.ts
+++ b/backend/src/utils/enums/simulation.enum.ts
@@ -13,5 +13,4 @@ export enum SimulationSuiteStatus {
   RUNNING = 'RUNNING',
   COMPLETED = 'COMPLETED',
   FAILED = 'FAILED',
-  ARCHIVED = 'ARCHIVED',
 }

--- a/backend/test/simulation-studio/simulation-studio.service.spec.ts
+++ b/backend/test/simulation-studio/simulation-studio.service.spec.ts
@@ -93,7 +93,7 @@ describe('SimulationStudioService', () => {
     expect(adminServiceClient.getSimulationSuiteById).toHaveBeenCalledWith('test-token', 101);
   });
 
-  it('createSimulationSuites maps alias fields and adds default wizard progress', async () => {
+  it('createSimulationSuites maps alias fields without wizard_progress override', async () => {
     const createDto: RequestSimulationSuitesDto = {
       name: 'Q3 Edge Cases',
       associated_rule: 'Rule 002',
@@ -112,9 +112,11 @@ describe('SimulationStudioService', () => {
         rule_name: 'Rule 002',
         primary_txtp: 'pacs.008',
         primary_txtp_version: 'v1.0',
-        wizard_progress: { step: 1, completed: false },
       }),
     );
+    // wizard_progress must NOT be sent — admin-service owns the default { currentStep: 1, completedSteps: [1] }
+    const callArg = (adminServiceClient.createSimulationSuite as jest.Mock).mock.calls[0][1] as Record<string, unknown>;
+    expect(callArg).not.toHaveProperty('wizard_progress');
   });
 
   it('patchSimulationSuite maps alias fields', async () => {

--- a/frontend/src/components/SimStudio/TxtpSelection/index.tsx
+++ b/frontend/src/components/SimStudio/TxtpSelection/index.tsx
@@ -2,6 +2,7 @@ import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import { useEffect, type MutableRefObject } from "react";
 import {
     Box,
     Collapse,
@@ -287,7 +288,11 @@ const EntryRow = ({
     </>
 );
 
-const TxtpSelection = () => {
+interface TxtpSelectionProps {
+    onSaveRef?: MutableRefObject<(() => Promise<boolean>) | null>;
+}
+
+const TxtpSelection = ({ onSaveRef }: TxtpSelectionProps) => {
     const { values, functions } = useTxtpSelectionController();
 
     const {
@@ -309,7 +314,14 @@ const TxtpSelection = () => {
         handleRemove,
         handleToggleExpand,
         handleFieldConfigChange,
+        saveStep2ToDb,
     } = functions;
+
+    // Register save fn with parent wizard so Next Step can call it
+    useEffect(() => {
+        if (onSaveRef) onSaveRef.current = saveStep2ToDb;
+        return () => { if (onSaveRef) onSaveRef.current = null; };
+    }, [onSaveRef, saveStep2ToDb]);
 
     return (
         <Box>

--- a/frontend/src/hooks/SimStudio/useCreateSimSuiteController.tsx
+++ b/frontend/src/hooks/SimStudio/useCreateSimSuiteController.tsx
@@ -1,11 +1,13 @@
 import { yupResolver } from "@hookform/resolvers/yup";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
+import toast from "react-hot-toast";
 import * as yup from "yup";
 import type { DropdownOption } from "../../components/DropDown";
 import { useSimStudioTab } from "../../contexts/SimStudioTabContext";
 import { useGetTypesQuery, useLazyGetTxtpVersionsQuery } from "../../redux/Api/Config";
+import { useCreateSuiteMutation } from "../../redux/Api/SimStudio";
 import { LocalStorage } from "../../utils/Common/enums";
 import { extractData, insertData } from "../../utils/Common/storage";
 import { SimStudioTabs } from "../../utils/Constants/data";
@@ -24,6 +26,7 @@ export interface Step1Values {
 
 export interface SimData {
     step1?: Step1Values;
+    suiteId?: number;
 }
 
 const step1Schema = yup.object({
@@ -88,6 +91,8 @@ const writeSimData = (patch: Partial<SimData>) => {
 const useCreateSimSuiteController = () => {
     const navigate = useNavigate();
     const { selectedTab, tabs, enableNextTab, enablePreviousTab } = useSimStudioTab();
+    const [createSuite, { isLoading: isCreatingSuite }] = useCreateSuiteMutation();
+    const step2SaveRef = useRef<(() => Promise<boolean>) | null>(null);
 
     useEffect(() => {
         localStorage.removeItem(SIM_DATA_KEY);
@@ -169,9 +174,28 @@ const useCreateSimSuiteController = () => {
 
     const handleNextStep = () => {
         if (selectedTab === SimStudioTabs[0].value) {
-            void handleSubmit((data) => {
+            void handleSubmit(async (data) => {
                 writeSimData({ step1: data });
-                enableNextTab();
+                try {
+                    const result = await createSuite({
+                        name: data.suite_name,
+                        description: data.description || undefined,
+                        rule_name: data.associated_rule?.value ? String(data.associated_rule.value) : undefined,
+                        rule_version: data.rule_version?.value ? String(data.rule_version.value) : undefined,
+                        primary_txtp: String(data.txtp!.value),
+                        primary_txtp_version: String(data.version!.value),
+                    }).unwrap();
+                    writeSimData({ suiteId: result.data.id });
+                    enableNextTab();
+                } catch {
+                    toast.error("Failed to create simulation suite. Please try again.");
+                }
+            })();
+        } else if (selectedTab === SimStudioTabs[1].value) {
+            void (async () => {
+                const save = step2SaveRef.current;
+                const ok = save ? await save() : true;
+                if (ok) enableNextTab();
             })();
         } else {
             enableNextTab();
@@ -193,7 +217,7 @@ const useCreateSimSuiteController = () => {
                         versionLoading={versionLoading}
                     />
                 );
-            case 'txtp_selection':      return <TxtpSelection />;
+            case 'txtp_selection':      return <TxtpSelection onSaveRef={step2SaveRef} />;
             case 'trigger_data':        return <PlaceholderStep title="Trigger Data" />;
             case 'enrichment_data':     return <PlaceholderStep title="Enrichment Data" />;
             case 'preview_save':        return <PlaceholderStep title="Preview & Save" />;
@@ -206,7 +230,7 @@ const useCreateSimSuiteController = () => {
     const currentStepIndex = tabs.findIndex(t => t.value === selectedTab);
 
     return {
-        values: { currentStepIndex, totalSteps: tabs.length },
+        values: { currentStepIndex, totalSteps: tabs.length, isCreatingSuite },
         functions: { handleBack, handleNextStep, renderStep },
     };
 };

--- a/frontend/src/hooks/SimStudio/useTxtpSelectionController.tsx
+++ b/frontend/src/hooks/SimStudio/useTxtpSelectionController.tsx
@@ -6,6 +6,13 @@ import {
     useLazyGetSamplePayloadQuery,
     useLazyGetTxtpVersionsQuery,
 } from "../../redux/Api/Config";
+import {
+    useLazyGetLatestGenerationQuery,
+    useLazyGetContextConfigsQuery,
+    useUpdateContextConfigMutation,
+    useUpsertFieldStrategiesMutation,
+    type UpsertFieldStrategyItem,
+} from "../../redux/Api/SimStudio";
 import { LocalStorage } from "../../utils/Common/enums";
 import { extractData, insertData } from "../../utils/Common/storage";
 
@@ -77,6 +84,11 @@ const readSimData = () => {
     }
 };
 
+const readSuiteId = (): number | null => {
+    const data = readSimData() as { suiteId?: number };
+    return data.suiteId ?? null;
+};
+
 const writeStep2 = (entries: TxtpEntry[]) => {
     const existing = readSimData();
     const step2 = entries.map((e) => ({
@@ -97,11 +109,17 @@ const useTxtpSelectionController = () => {
     const [addTxtp, setAddTxtp] = useState<DropdownOption | null>(null);
     const [addVersion, setAddVersion] = useState<DropdownOption | null>(null);
     const [numMessages, setNumMessages] = useState<number>(100);
+    const [configId, setConfigId] = useState<number | null>(null);
+    const [isSaving, setIsSaving] = useState(false);
 
     const { data: txTypesData } = useGetTypesQuery({});
     const [fetchVersionsForAdd, { data: addVersionsData, isFetching: addVersionsLoading }] =
         useLazyGetTxtpVersionsQuery();
     const [getPayload] = useLazyGetSamplePayloadQuery();
+    const [fetchLatestGeneration] = useLazyGetLatestGenerationQuery();
+    const [fetchContextConfigs] = useLazyGetContextConfigsQuery();
+    const [updateContextConfig] = useUpdateContextConfigMutation();
+    const [upsertFieldStrategies] = useUpsertFieldStrategiesMutation();
 
     const txTypeOptions = useMemo<DropdownOption[]>(() => {
         if (!txTypesData || !Array.isArray(txTypesData)) return [];
@@ -172,22 +190,96 @@ const useTxtpSelectionController = () => {
         [getPayload]
     );
 
+    // On mount: build primary entry from step1 data, then sync message_count
+    // from the seeded context_txtp_config row in the DB.
     useEffect(() => {
         if (initialized.current) return;
         initialized.current = true;
 
         const simData = readSimData() as {
             step1?: { txtp?: { value: string }; version?: { value: string } };
+            suiteId?: number;
         };
         const txtp = simData.step1?.txtp?.value;
         const version = simData.step1?.version?.value;
         if (!txtp || !version) return;
 
-        void buildEntry(txtp, version, 100).then((entry) => {
-            setEntries([entry]);
-            writeStep2([entry]);
+        const suiteId = simData.suiteId;
+
+        void buildEntry(txtp, version, 100).then(async (entry) => {
+            let initialMsgs = 100;
+
+            // Fetch the seeded context config to get message_count + configId
+            if (suiteId) {
+                try {
+                    const genRes = await fetchLatestGeneration(suiteId).unwrap();
+                    if (genRes.data?.id) {
+                        const cfgRes = await fetchContextConfigs(genRes.data.id).unwrap();
+                        const primary = cfgRes.data?.[0];
+                        if (primary) {
+                            setConfigId(primary.id);
+                            initialMsgs = primary.message_count ?? 100;
+                        }
+                    }
+                } catch {
+                    // non-blocking — UI still works without DB sync
+                }
+            }
+
+            const hydrated = { ...entry, numMessages: initialMsgs };
+            setEntries([hydrated]);
+            writeStep2([hydrated]);
         });
-    }, [buildEntry]);
+    }, [buildEntry, fetchLatestGeneration, fetchContextConfigs]);
+
+    // Called by parent wizard on "Next Step" — persists message_count + field strategies
+    const saveStep2ToDb = useCallback(async (): Promise<boolean> => {
+        const suiteId = readSuiteId();
+        if (!suiteId || configId === null) return true; // no suite yet, skip silently
+
+        setIsSaving(true);
+        try {
+            const primaryEntry = entries[0];
+            if (primaryEntry) {
+                await updateContextConfig({
+                    suiteId,
+                    configId,
+                    message_count: primaryEntry.numMessages,
+                }).unwrap();
+
+                const strategies: UpsertFieldStrategyItem[] = Object.entries(
+                    primaryEntry.fieldConfigs
+                ).map(([fieldPath, cfg]) => {
+                    const base = { field_path: fieldPath } as UpsertFieldStrategyItem;
+                    switch (cfg.action) {
+                        case "static":
+                            return { ...base, strategy_code: "static", static_value: cfg.staticValue };
+                        case "range":
+                            return {
+                                ...base,
+                                strategy_code: "range",
+                                range_min: cfg.rangeStart ? Number(cfg.rangeStart) : undefined,
+                                range_max: cfg.rangeEnd ? Number(cfg.rangeEnd) : undefined,
+                            };
+                        case "skip":
+                            return { ...base, strategy_code: "skip" };
+                        default:
+                            return { ...base, strategy_code: "keep_sample" };
+                    }
+                });
+
+                if (strategies.length > 0) {
+                    await upsertFieldStrategies({ suiteId, configId, strategies }).unwrap();
+                }
+            }
+            return true;
+        } catch {
+            toast.error("Failed to save TXTP configuration. Please try again.");
+            return false;
+        } finally {
+            setIsSaving(false);
+        }
+    }, [entries, configId, updateContextConfig, upsertFieldStrategies]);
 
     const handleAdd = useCallback(() => {
         if (!addTxtp?.value || !addVersion?.value) {
@@ -248,6 +340,7 @@ const useTxtpSelectionController = () => {
             addVersionsLoading,
             numMessages,
             adding,
+            isSaving,
         },
         functions: {
             handleTxtpChange,
@@ -257,6 +350,7 @@ const useTxtpSelectionController = () => {
             handleRemove,
             handleToggleExpand,
             handleFieldConfigChange,
+            saveStep2ToDb,
         },
     };
 };

--- a/frontend/src/pages/SimStudio/CreateSimSuite/index.tsx
+++ b/frontend/src/pages/SimStudio/CreateSimSuite/index.tsx
@@ -55,6 +55,7 @@ const CreateSimSuiteContent = () => {
                     variant="contained"
                     endIcon={<ChevronRightIcon />}
                     onClick={functions.handleNextStep}
+                    disabled={values.isCreatingSuite}
                     sx={{
                         textTransform: "none",
                         height: "38px",
@@ -66,7 +67,7 @@ const CreateSimSuiteContent = () => {
                         color: "#fff",
                     }}
                 >
-                    Next Step
+                    {values.isCreatingSuite ? "Creating..." : "Next Step"}
                 </Button>
             </S.BottomBar>
         </S.PageContainer>

--- a/frontend/src/pages/SimStudio/index.tsx
+++ b/frontend/src/pages/SimStudio/index.tsx
@@ -134,9 +134,10 @@ const SimStudio = () => {
                     sx={S.selectSx}
                 >
                     <MenuItem value="">All Statuses</MenuItem>
-                    <MenuItem value="Ready for Simulation">Ready for Simulation</MenuItem>
-                    <MenuItem value="Draft">Draft</MenuItem>
-                    <MenuItem value="Generated">Generated</MenuItem>
+                    <MenuItem value="DRAFT">Draft</MenuItem>
+                    <MenuItem value="RUNNING">Running</MenuItem>
+                    <MenuItem value="COMPLETED">Completed</MenuItem>
+                    <MenuItem value="FAILED">Failed</MenuItem>
                 </Select>
                 <Select
                     size="small"

--- a/frontend/src/pages/SimStudio/useSimStudioController.tsx
+++ b/frontend/src/pages/SimStudio/useSimStudioController.tsx
@@ -3,87 +3,18 @@ import { useNavigate } from "react-router-dom";
 import StatusCard from "../../components/Cards/StatusCard";
 import type { TableColumn } from "../../components/Table";
 import useDebouncedSearch from "../../hooks/useDebouncedSearch";
+import { useGetSuitesQuery, type SuiteListItem } from "../../redux/Api/SimStudio";
 import * as S from "./SimStudio.styles";
 import SimStudioActions from "./SimStudioActions";
 
-export type SimSuiteStatus = "Ready for Simulation" | "Draft" | "Generated";
-
-export interface SimSuite {
-    id: string;
-    suite_name: string;
-    associated_rule: string;
-    txtp: string;
-    status: SimSuiteStatus;
-    iterations: number;
-    last_updated: string;
-}
-
-const MOCK_DATA: SimSuite[] = [
-    {
-        id: "1",
-        suite_name: "High Value Txns - Q3",
-        associated_rule: "Rule 001",
-        txtp: "pacs.008",
-        status: "Ready for Simulation",
-        iterations: 3,
-        last_updated: "2023-10-24",
-    },
-    {
-        id: "2",
-        suite_name: "Velocity Edge Cases",
-        associated_rule: "Rule 002",
-        txtp: "pacs.002",
-        status: "Draft",
-        iterations: 0,
-        last_updated: "2023-10-25",
-    },
-    {
-        id: "3",
-        suite_name: "Cross-border Anomalies",
-        associated_rule: "Rule 003",
-        txtp: "pain.001",
-        status: "Generated",
-        iterations: 1,
-        last_updated: "2026-05-21",
-    },
-    {
-        id: "4",
-        suite_name: "Duplicate Transaction Sweep",
-        associated_rule: "Rule 001",
-        txtp: "pacs.008",
-        status: "Ready for Simulation",
-        iterations: 2,
-        last_updated: "2023-10-20",
-    },
-    {
-        id: "5",
-        suite_name: "Rapid Transfer Burst",
-        associated_rule: "Rule 004",
-        txtp: "pain.001",
-        status: "Draft",
-        iterations: 0,
-        last_updated: "2023-10-22",
-    },
-    {
-        id: "6",
-        suite_name: "Offshore Routing Test",
-        associated_rule: "Rule 005",
-        txtp: "pacs.002",
-        status: "Generated",
-        iterations: 4,
-        last_updated: "2023-10-18",
-    },
-];
-
-const AVAILABLE_RULES = [...new Set(MOCK_DATA.map((d) => d.associated_rule))];
-const AVAILABLE_TXTPS = [...new Set(MOCK_DATA.map((d) => d.txtp))];
-
-const computeLatestIteration = (data: SimSuite[]): string => {
-    if (data.length === 0) return "—";
-    const latest = data.reduce((acc, curr) =>
-        new Date(curr.last_updated) > new Date(acc.last_updated) ? curr : acc
+const computeLatestIteration = (suites: SuiteListItem[]): string => {
+    if (suites.length === 0) return "—";
+    const withRuns = suites.filter((s) => s.last_run_at);
+    if (withRuns.length === 0) return "—";
+    const latest = withRuns.reduce((acc, curr) =>
+        new Date(curr.last_run_at!) > new Date(acc.last_run_at!) ? curr : acc
     );
-    const latestDate = new Date(latest.last_updated);
+    const latestDate = new Date(latest.last_run_at!);
     const today = new Date();
     if (latestDate.toDateString() === today.toDateString()) return "Today";
     return latestDate.toLocaleDateString("en-GB", { day: "2-digit", month: "short" });
@@ -98,26 +29,49 @@ const useSimStudioController = () => {
     const [lastUpdatedFrom, setLastUpdatedFrom] = useState<string>("");
     const [lastUpdatedTo, setLastUpdatedTo] = useState<string>("");
 
-    const stats = useMemo(() => ({
-        total: MOCK_DATA.length,
-        readyForSimulation: MOCK_DATA.filter((d) => d.status === "Ready for Simulation").length,
-        drafts: MOCK_DATA.filter((d) => d.status === "Draft").length,
-        latestIteration: computeLatestIteration(MOCK_DATA),
-    }), []);
+    const queryParams = useMemo(() => ({
+        search: debouncedSearch || undefined,
+        status: statusFilter || undefined,
+        rule_name: ruleFilter || undefined,
+        txtp: txtpFilter || undefined,
+        updated_from: lastUpdatedFrom || undefined,
+        updated_to: lastUpdatedTo || undefined,
+        limit: 100,
+        offset: 0,
+    }), [debouncedSearch, statusFilter, ruleFilter, txtpFilter, lastUpdatedFrom, lastUpdatedTo]);
 
-    const filteredData = useMemo(() => {
-        return MOCK_DATA.filter((suite) => {
-            const matchesSearch =
-                debouncedSearch.trim() === "" ||
-                suite.suite_name.toLowerCase().includes(debouncedSearch.toLowerCase());
-            const matchesStatus = statusFilter === "" || suite.status === statusFilter;
-            const matchesRule = ruleFilter === "" || suite.associated_rule === ruleFilter;
-            const matchesTxtp = txtpFilter === "" || suite.txtp === txtpFilter;
-            const matchesFrom = lastUpdatedFrom === "" || suite.last_updated >= lastUpdatedFrom;
-            const matchesTo = lastUpdatedTo === "" || suite.last_updated <= lastUpdatedTo;
-            return matchesSearch && matchesStatus && matchesRule && matchesTxtp && matchesFrom && matchesTo;
-        });
-    }, [debouncedSearch, statusFilter, ruleFilter, txtpFilter, lastUpdatedFrom, lastUpdatedTo]);
+    const { data, isLoading, isFetching } = useGetSuitesQuery(queryParams);
+
+    const suites: SuiteListItem[] = data?.suites ?? [];
+
+    const availableRules = useMemo(
+        () => [...new Set(suites.map((s) => s.rule_name).filter(Boolean) as string[])],
+        [suites]
+    );
+    const availableTxtps = useMemo(
+        () => [...new Set(suites.map((s) => s.primary_txtp).filter(Boolean) as string[])],
+        [suites]
+    );
+
+    const stats = useMemo(() => ({
+        total: data?.total ?? suites.length,
+        readyForSimulation: suites.filter((s) => s.status === "COMPLETED" || s.status === "RUNNING").length,
+        drafts: suites.filter((s) => s.status === "DRAFT").length,
+        latestIteration: computeLatestIteration(suites),
+    }), [data, suites]);
+
+    const tableData = useMemo(() =>
+        suites.map((s) => ({
+            id: s.id,
+            suite_name: s.name,
+            associated_rule: s.rule_name ?? "—",
+            txtp: s.primary_txtp ?? "—",
+            status: s.status,
+            iterations: s.iteration_count,
+            last_updated: s.updated_at ? s.updated_at.split("T")[0] : "—",
+        })),
+        [suites]
+    );
 
     const hasAdvancedFilters = txtpFilter !== "" || lastUpdatedFrom !== "" || lastUpdatedTo !== "";
     const hasAnyFilter =
@@ -151,10 +105,7 @@ const useSimStudioController = () => {
             key: "suite_name",
             sx: { fontWeight: 600, color: "#1f2937" },
         },
-        {
-            label: "Associated Rule",
-            key: "associated_rule",
-        },
+        { label: "Associated Rule", key: "associated_rule" },
         {
             label: "TXTP",
             key: "txtp",
@@ -186,18 +137,18 @@ const useSimStudioController = () => {
 
     return {
         values: {
-            isLoading: false,
+            isLoading: isLoading || isFetching,
             searchInput,
             statusFilter,
             ruleFilter,
             txtpFilter,
             lastUpdatedFrom,
             lastUpdatedTo,
-            filteredData,
+            filteredData: tableData,
             stats,
             columns,
-            availableRules: AVAILABLE_RULES,
-            availableTxtps: AVAILABLE_TXTPS,
+            availableRules,
+            availableTxtps,
             hasAdvancedFilters,
             hasAnyFilter,
         },

--- a/frontend/src/redux/Api/SimStudio/index.ts
+++ b/frontend/src/redux/Api/SimStudio/index.ts
@@ -1,0 +1,170 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { getAuthToken } from "../../../utils/Common/storage";
+
+const BASE_URL = import.meta.env.VITE_API_URL as string;
+
+export interface CreateSuitePayload {
+    name: string;
+    description?: string;
+    rule_repo?: string;
+    rule_name?: string;
+    rule_version?: string;
+    primary_txtp: string;
+    primary_txtp_version: string;
+    wizard_progress?: Record<string, unknown>;
+    metadata?: Record<string, unknown>;
+}
+
+export interface SuiteGeneration {
+    id: number;
+    suite_id: number;
+    generation_number: number;
+    status: string;
+    simulation_type: string;
+}
+
+export interface ContextTxtpConfig {
+    id: number;
+    generation_id: number;
+    txtp: string;
+    txtp_version: string;
+    display_order: number;
+    message_count: number;
+    faker_seed?: number;
+    schema_snapshot: Record<string, unknown>;
+    sample_payload_snapshot?: Record<string, unknown>;
+    generator_profile?: Record<string, unknown>;
+}
+
+export interface FieldStrategy {
+    id: number;
+    context_txtp_config_id: number;
+    field_path: string;
+    strategy_code: string;
+    static_value?: unknown;
+    range_min?: number;
+    range_max?: number;
+    generator_type?: string;
+    generator_options?: Record<string, unknown>;
+    is_required_override?: boolean;
+}
+
+export interface UpsertFieldStrategyItem {
+    field_path: string;
+    strategy_code: "keep_sample" | "static" | "range" | "generated" | "null" | "skip";
+    static_value?: unknown;
+    range_min?: number;
+    range_max?: number;
+    generator_type?: string;
+    generator_options?: Record<string, unknown>;
+    is_required_override?: boolean;
+}
+
+export interface SuiteListItem {
+    id: number;
+    name: string;
+    rule_name?: string;
+    primary_txtp?: string;
+    status: string;
+    iteration_count: number;
+    run_count: number;
+    last_run_at?: string;
+    updated_at: string;
+    created_by: string;
+    wizard_progress: Record<string, unknown>;
+}
+
+export interface SuitesListResponse {
+    success: boolean;
+    message: string;
+    suites: SuiteListItem[];
+    total: number;
+}
+
+export interface SuitesListQuery {
+    search?: string;
+    status?: string;
+    rule_name?: string;
+    txtp?: string;
+    updated_from?: string;
+    updated_to?: string;
+    offset?: number;
+    limit?: number;
+}
+
+export const simStudioApi = createApi({
+    reducerPath: "simStudioApi",
+    baseQuery: fetchBaseQuery({
+        baseUrl: `${BASE_URL}/simulation-studio/`,
+        prepareHeaders: (headers) => {
+            const token = getAuthToken();
+            if (token) headers.set("authorization", `Bearer ${token}`);
+            return headers;
+        },
+    }),
+    endpoints: (builder) => ({
+        getSuites: builder.query<SuitesListResponse, SuitesListQuery>({
+            query: (params = {}) => {
+                const q = new URLSearchParams();
+                if (params.search) q.set("search", params.search);
+                if (params.status) q.set("status", params.status);
+                if (params.rule_name) q.set("rule_name", params.rule_name);
+                if (params.txtp) q.set("txtp", params.txtp);
+                if (params.updated_from) q.set("updated_from", params.updated_from);
+                if (params.updated_to) q.set("updated_to", params.updated_to);
+                if (params.offset !== undefined) q.set("offset", String(params.offset));
+                if (params.limit !== undefined) q.set("limit", String(params.limit));
+                return `suites${q.toString() ? `?${q.toString()}` : ""}`;
+            },
+        }),
+
+        createSuite: builder.mutation<{ success: boolean; data: { id: number; wizard_progress: Record<string, unknown> } }, CreateSuitePayload>({
+            query: (body) => ({
+                url: "suites",
+                method: "POST",
+                body,
+            }),
+        }),
+
+        getLatestGeneration: builder.query<{ success: boolean; data: SuiteGeneration }, number>({
+            query: (suiteId) => `suites/${suiteId}/generations/latest`,
+        }),
+
+        getContextConfigs: builder.query<{ success: boolean; data: ContextTxtpConfig[] }, number>({
+            query: (generationId) => `generations/${generationId}/context-configs`,
+        }),
+
+        updateContextConfig: builder.mutation<
+            { success: boolean; data: ContextTxtpConfig },
+            { suiteId: number; configId: number; message_count?: number; faker_seed?: number; generator_profile?: Record<string, unknown> }
+        >({
+            query: ({ suiteId, configId, ...body }) => ({
+                url: `suites/${suiteId}/context-configs/${configId}`,
+                method: "PATCH",
+                body,
+            }),
+        }),
+
+        upsertFieldStrategies: builder.mutation<
+            { success: boolean; data: FieldStrategy[] },
+            { suiteId: number; configId: number; strategies: UpsertFieldStrategyItem[] }
+        >({
+            query: ({ suiteId, configId, strategies }) => ({
+                url: `suites/${suiteId}/context-configs/${configId}/field-strategies`,
+                method: "PUT",
+                body: { strategies },
+            }),
+        }),
+    }),
+});
+
+export const {
+    useGetSuitesQuery,
+    useCreateSuiteMutation,
+    useGetLatestGenerationQuery,
+    useLazyGetLatestGenerationQuery,
+    useGetContextConfigsQuery,
+    useLazyGetContextConfigsQuery,
+    useUpdateContextConfigMutation,
+    useUpsertFieldStrategiesMutation,
+} = simStudioApi;

--- a/frontend/src/redux/Store/index.ts
+++ b/frontend/src/redux/Store/index.ts
@@ -13,6 +13,7 @@ import { maskingApi } from '../Api/Masking'
 import { sendToDemsApi } from '../Api/SendToDems'
 import { ruleSimulationApi } from '../Api/RuleSimulation'
 import { fetchFromDlhApi } from '../Api/FetchDromDlh'
+import { simStudioApi } from '../Api/SimStudio'
 
 export default configureStore({
     reducer: {
@@ -28,6 +29,7 @@ export default configureStore({
         [sendToDemsApi.reducerPath]: sendToDemsApi.reducer,
         [ruleSimulationApi.reducerPath]: ruleSimulationApi.reducer,
         [fetchFromDlhApi.reducerPath]: fetchFromDlhApi.reducer,
+        [simStudioApi.reducerPath]: simStudioApi.reducer,
     },
     middleware: (getDefaultMiddleware) =>
         getDefaultMiddleware({
@@ -45,6 +47,7 @@ export default configureStore({
             .concat(sendToDemsApi.middleware)
             .concat(ruleSimulationApi.middleware)
             .concat(fetchFromDlhApi.middleware)
+            .concat(simStudioApi.middleware)
             .concat(errorLogger)
             .concat(successLogger)
 })


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0
This pull request introduces significant improvements to the SimStudio simulation suite creation flow, focusing on better backend synchronization, improved user experience, and enhanced state management. The main changes include removing the frontend override of `wizard_progress`, ensuring step data is persisted to the backend, and providing user feedback during suite creation. The changes also refactor the step navigation logic to support asynchronous step saving and backend updates.

**Backend API and Data Model Updates**
* The `wizard_progress` field is no longer set by the frontend when creating a simulation suite; instead, the backend is responsible for initializing this state. [[1]](diffhunk://#diff-7c0f59d9e3462b18ab4733f88c42df4aca6480e760cb7a6da3902ec0ff46196bL62) [[2]](diffhunk://#diff-1bc6e56adac2725d90cc4da8d9e2c31797559a1259bbdd6fb4f304532e351c43L96-R96) [[3]](diffhunk://#diff-1bc6e56adac2725d90cc4da8d9e2c31797559a1259bbdd6fb4f304532e351c43L115-R119)
* The `ARCHIVED` status has been removed from the `SimulationSuiteStatus` enum, aligning the frontend with the supported backend statuses.

**Simulation Suite Creation & Step Navigation**
* The simulation suite is now created as soon as the user completes step 1, and the returned `suiteId` is persisted for use in subsequent steps. [[1]](diffhunk://#diff-be1123e88418a6bcf2ac8e129c87ee77448bb1ab59eeac891bcac07d411f5219R29) [[2]](diffhunk://#diff-be1123e88418a6bcf2ac8e129c87ee77448bb1ab59eeac891bcac07d411f5219L172-R198)
* The wizard navigation logic has been updated to support asynchronous step validation and saving, allowing each step to register a save function (e.g., `saveStep2ToDb` for the TXTP selection step). [[1]](diffhunk://#diff-be1123e88418a6bcf2ac8e129c87ee77448bb1ab59eeac891bcac07d411f5219R94-R95) [[2]](diffhunk://#diff-be1123e88418a6bcf2ac8e129c87ee77448bb1ab59eeac891bcac07d411f5219L172-R198) [[3]](diffhunk://#diff-d472f4020ff255c21a50ae6c7dbe090d522edf9a108c34b97d0d30c7dfe3de0fL290-R295) [[4]](diffhunk://#diff-d472f4020ff255c21a50ae6c7dbe090d522edf9a108c34b97d0d30c7dfe3de0fR317-R325) [[5]](diffhunk://#diff-be1123e88418a6bcf2ac8e129c87ee77448bb1ab59eeac891bcac07d411f5219L196-R220)

**Backend Synchronization for TXTP Selection**
* The TXTP selection step now fetches and syncs the initial message count and configuration from the backend using the newly created suite ID, and persists user changes (message count and field strategies) back to the backend when the user advances the wizard. [[1]](diffhunk://#diff-acefcee94f4ab0bdd8f523f2f5222037f86729945b96305a926bc162fca0cd56R9-R15) [[2]](diffhunk://#diff-acefcee94f4ab0bdd8f523f2f5222037f86729945b96305a926bc162fca0cd56R87-R91) [[3]](diffhunk://#diff-acefcee94f4ab0bdd8f523f2f5222037f86729945b96305a926bc162fca0cd56R112-R122) [[4]](diffhunk://#diff-acefcee94f4ab0bdd8f523f2f5222037f86729945b96305a926bc162fca0cd56R193-R282) [[5]](diffhunk://#diff-acefcee94f4ab0bdd8f523f2f5222037f86729945b96305a926bc162fca0cd56R353)

**User Experience Improvements**
* The "Next Step" button is disabled and shows a loading indicator while the simulation suite is being created, preventing duplicate submissions and providing clear feedback. [[1]](diffhunk://#diff-7f3a7354edfd67428cfbfa8dc6cd37b020ebf5bd30bbd3b6786887d1ed8883ebR58) [[2]](diffhunk://#diff-7f3a7354edfd67428cfbfa8dc6cd37b020ebf5bd30bbd3b6786887d1ed8883ebL69-R70)
* Error handling and toast notifications have been added for failed suite creation and TXTP configuration saves. [[1]](diffhunk://#diff-be1123e88418a6bcf2ac8e129c87ee77448bb1ab59eeac891bcac07d411f5219L172-R198) [[2]](diffhunk://#diff-acefcee94f4ab0bdd8f523f2f5222037f86729945b96305a926bc162fca0cd56R193-R282)

**UI Consistency**
* The simulation suite status filter now uses backend-aligned status values (`DRAFT`, `RUNNING`, `COMPLETED`, `FAILED`) instead of legacy strings.
## What did we change?

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done