### PR TITLE
feat: create trigger txtp workflow

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -21,6 +21,7 @@ import { DockerHubModule } from './services/dockerhub/dockerhub.module';
 import { SimulationStudioModule } from './services/simulation-studio/simulation-studio.module';
 import { GenerationsModule } from './services/simulation-studio/generations/generations.module';
 import { ContextTxtpConfigModule } from './services/simulation-studio/context-txtp-config/context-txtp-config.module';
+import { TriggerTxtpConfigModule } from './services/simulation-studio/trigger-txtp-config/trigger-txtp-config.module';
 
 @Module({
   imports: [
@@ -46,6 +47,7 @@ import { ContextTxtpConfigModule } from './services/simulation-studio/context-tx
     SimulationStudioModule,
     GenerationsModule,
     ContextTxtpConfigModule,
+    TriggerTxtpConfigModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/constants/constant.ts
+++ b/backend/src/constants/constant.ts
@@ -70,3 +70,5 @@ export const SUITE_GENERATIONS = (suiteId: number): string => `${SIMULATION_SUIT
 export const SUITE_LATEST_GENERATION = (suiteId: number): string => `${SIMULATION_SUITES}/${suiteId}/generations/latest`;
 export const GENERATION_CONTEXT_CONFIGS = (generationId: number): string =>
   `${SIMULATION_STUDIO_BASE_URL}/generations/${generationId}/context-configs`;
+export const GENERATION_TRIGGER_CONFIGS = (generationId: number): string =>
+  `${SIMULATION_STUDIO_BASE_URL}/generations/${generationId}/trigger-configs`;

--- a/backend/src/services/admin-service-client.ts
+++ b/backend/src/services/admin-service-client.ts
@@ -50,6 +50,7 @@ import {
   SUITE_GENERATIONS,
   SUITE_LATEST_GENERATION,
   GENERATION_CONTEXT_CONFIGS,
+  GENERATION_TRIGGER_CONFIGS,
   SIMULATION_ITEMS,
   EXCLUDED_TYPES,
   STAGE_SIMULATION_ITEMS,
@@ -577,5 +578,19 @@ export class AdminServiceClient {
 
   async bulkUpdateContextConfigs<T>(token: string, generationId: number, body: unknown): Promise<T> {
     return await this.executeHttpRequest<T>('PATCH', GENERATION_CONTEXT_CONFIGS(generationId), token, body);
+  }
+
+  // ── Trigger TXTP Config ───────────────────────────────────────────────────────
+
+  async getTriggerConfigs<T>(token: string, generationId: number): Promise<T> {
+    return await this.executeHttpRequest<T>('GET', GENERATION_TRIGGER_CONFIGS(generationId), token);
+  }
+
+  async addTriggerTxtpConfig<T>(token: string, generationId: number, body: unknown): Promise<T> {
+    return await this.executeHttpRequest<T>('POST', GENERATION_TRIGGER_CONFIGS(generationId), token, body);
+  }
+
+  async bulkUpdateTriggerConfigs<T>(token: string, generationId: number, body: unknown): Promise<T> {
+    return await this.executeHttpRequest<T>('PATCH', GENERATION_TRIGGER_CONFIGS(generationId), token, body);
   }
 }

--- a/backend/src/services/simulation-studio/generations/dto/generations.dto.ts
+++ b/backend/src/services/simulation-studio/generations/dto/generations.dto.ts
@@ -346,3 +346,194 @@ export class BulkUpdateContextConfigsResponseDto {
   @ApiProperty({ type: [ContextTxtpConfigWithStrategiesDto] })
   data: ContextTxtpConfigWithStrategiesDto[];
 }
+
+// ── Trigger TXTP Config DTOs ──────────────────────────────────────────────────
+
+export class AddTriggerTxtpConfigDto {
+  @ApiProperty({ example: 'pacs.008', description: 'Transaction type (same as primary TXTP)' })
+  @IsString()
+  txtp: string;
+
+  @ApiProperty({ example: '001.08', description: 'Transaction type version' })
+  @IsString()
+  txtp_version: string;
+
+  @ApiProperty({ required: false, example: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  message_count?: number;
+}
+
+export class TriggerFieldOverrideDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 1 })
+  trigger_txtp_config_id: number;
+
+  @ApiProperty({ example: 'CdtTrfTxInf.IntrBkSttlmAmt.value' })
+  field_path: string;
+
+  @ApiProperty({ example: 'static', enum: ['static', 'range', 'generated', 'remove', 'null'] })
+  override_type: string;
+
+  @ApiProperty({ required: false })
+  static_value?: unknown;
+
+  @ApiProperty({ required: false, example: 100 })
+  range_min?: number;
+
+  @ApiProperty({ required: false, example: 9999 })
+  range_max?: number;
+
+  @ApiProperty({ required: false, example: 'iso20022.bic' })
+  generator_type?: string;
+
+  @ApiProperty({ required: false, example: {} })
+  generator_options?: Record<string, unknown>;
+
+  @ApiProperty()
+  created_at: string;
+}
+
+export class UpsertTriggerFieldOverrideDto {
+  @ApiProperty({ example: 'CdtTrfTxInf.IntrBkSttlmAmt.value' })
+  @IsString()
+  field_path: string;
+
+  @ApiProperty({ example: 'static', enum: ['static', 'range', 'generated', 'remove', 'null'] })
+  @IsEnum(['static', 'range', 'generated', 'remove', 'null'])
+  override_type: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  static_value?: unknown;
+
+  @ApiProperty({ required: false, example: 100 })
+  @IsOptional()
+  @IsNumber()
+  range_min?: number;
+
+  @ApiProperty({ required: false, example: 9999 })
+  @IsOptional()
+  @IsNumber()
+  range_max?: number;
+
+  @ApiProperty({ required: false, example: 'iso20022.bic' })
+  @IsOptional()
+  @IsString()
+  generator_type?: string;
+
+  @ApiProperty({ required: false, example: {} })
+  @IsOptional()
+  @IsObject()
+  generator_options?: Record<string, unknown>;
+}
+
+export class TriggerTxtpConfigWithOverridesDto {
+  @ApiProperty({ example: 1 })
+  trigger_txtp_config_id: number;
+
+  @ApiProperty({ example: 'pacs.008' })
+  txtp: string;
+
+  @ApiProperty({ example: '001.08' })
+  txtp_version: string;
+
+  @ApiProperty({ example: 1 })
+  message_count: number;
+
+  @ApiProperty({ example: 1 })
+  display_order: number;
+
+  @ApiProperty({ example: {} })
+  payload_template_json: Record<string, unknown>;
+
+  @ApiProperty({ example: false })
+  link_to_context_pairs: boolean;
+
+  @ApiProperty({ required: false, example: 'good', enum: ['good', 'neutral', 'bad', 'error'] })
+  expected_result_band?: string;
+
+  @ApiProperty({ required: false, example: 'optional notes' })
+  notes?: string;
+
+  @ApiProperty({ type: [TriggerFieldOverrideDto] })
+  field_overrides: TriggerFieldOverrideDto[];
+}
+
+export class TriggerConfigsListDto {
+  @ApiProperty()
+  success: boolean;
+
+  @ApiProperty({ type: [TriggerTxtpConfigWithOverridesDto] })
+  data: TriggerTxtpConfigWithOverridesDto[];
+}
+
+export class TriggerConfigWithOverridesResponseDto {
+  @ApiProperty()
+  success: boolean;
+
+  @ApiProperty({ type: TriggerTxtpConfigWithOverridesDto })
+  data: TriggerTxtpConfigWithOverridesDto;
+}
+
+export class BulkTriggerConfigItemDto {
+  @ApiProperty({ example: 1 })
+  @IsInt()
+  trigger_txtp_config_id: number;
+
+  @ApiProperty({ required: false, example: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  message_count?: number;
+
+  @ApiProperty({ required: false, example: false })
+  @IsOptional()
+  link_to_context_pairs?: boolean;
+
+  @ApiProperty({ required: false, example: {} })
+  @IsOptional()
+  @IsObject()
+  payload_template_json?: Record<string, unknown>;
+
+  @ApiProperty({ required: false, example: 'good', enum: ['good', 'neutral', 'bad', 'error'] })
+  @IsOptional()
+  @IsString()
+  expected_result_band?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  notes?: string;
+
+  @ApiProperty({ required: false, example: 42 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  faker_seed?: number;
+
+  @ApiProperty({ required: false, example: {} })
+  @IsOptional()
+  @IsObject()
+  generator_profile?: Record<string, unknown>;
+
+  @ApiProperty({ required: false, type: [UpsertTriggerFieldOverrideDto] })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => UpsertTriggerFieldOverrideDto)
+  field_overrides?: UpsertTriggerFieldOverrideDto[];
+}
+
+export class BulkUpdateTriggerConfigsResponseDto {
+  @ApiProperty()
+  success: boolean;
+
+  @ApiProperty({ type: [TriggerTxtpConfigWithOverridesDto] })
+  data: TriggerTxtpConfigWithOverridesDto[];
+}

--- a/backend/src/services/simulation-studio/trigger-txtp-config/dto/trigger-txtp-config.dto.ts
+++ b/backend/src/services/simulation-studio/trigger-txtp-config/dto/trigger-txtp-config.dto.ts
@@ -1,0 +1,10 @@
+export {
+  AddTriggerTxtpConfigDto,
+  TriggerFieldOverrideDto,
+  UpsertTriggerFieldOverrideDto,
+  TriggerTxtpConfigWithOverridesDto,
+  TriggerConfigsListDto,
+  TriggerConfigWithOverridesResponseDto,
+  BulkTriggerConfigItemDto,
+  BulkUpdateTriggerConfigsResponseDto,
+} from '../../generations/dto/generations.dto';

--- a/backend/src/services/simulation-studio/trigger-txtp-config/trigger-txtp-config.controller.ts
+++ b/backend/src/services/simulation-studio/trigger-txtp-config/trigger-txtp-config.controller.ts
@@ -1,0 +1,86 @@
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiParam, ApiBody } from '@nestjs/swagger';
+import { RequireAnyClaims, TazamaClaims } from 'src/decorators/auth.decorator';
+import { ApiSwagger, mergeResponses, CommonResponses } from 'src/decorators/swagger.decorator';
+import { TazamaAuthGuard } from 'src/guards/tazama-auth.guard';
+import { User } from 'src/decorators/user.decorator';
+import { Audit } from 'src/decorators/audit.decorator';
+import type { AuthenticatedUser } from '../../auth/auth.types';
+import { TriggerTxtpConfigService } from './trigger-txtp-config.service';
+import {
+  AddTriggerTxtpConfigDto,
+  BulkTriggerConfigItemDto,
+  TriggerConfigsListDto,
+  TriggerConfigWithOverridesResponseDto,
+  BulkUpdateTriggerConfigsResponseDto,
+} from './dto/trigger-txtp-config.dto';
+
+@ApiTags('simulation-studio')
+@ApiBearerAuth('JWT-auth')
+@Controller('simulation-studio')
+@UseGuards(TazamaAuthGuard)
+export class TriggerTxtpConfigController {
+  constructor(private readonly triggerTxtpConfigService: TriggerTxtpConfigService) {}
+
+  @Get('generations/:generationId/trigger-configs')
+  @RequireAnyClaims(TazamaClaims.EDITOR, TazamaClaims.APPROVER)
+  @ApiParam({ name: 'generationId', description: 'Suite generation id', example: 1 })
+  @ApiSwagger({
+    summary: 'Get all trigger TXTP configs with field overrides (Step 3)',
+    description: 'Returns all trigger txtp configs and their field overrides for the given generation.',
+    responses: mergeResponses(
+      CommonResponses.SUCCESS_200(TriggerConfigsListDto, 'Trigger configs retrieved successfully'),
+      CommonResponses.NOT_FOUND_404('Generation not found'),
+    ),
+  })
+  async getTriggerConfigs(
+    @Param('generationId', ParseIntPipe) generationId: number,
+    @User() user: AuthenticatedUser,
+  ): Promise<TriggerConfigsListDto> {
+    return await this.triggerTxtpConfigService.getTriggerConfigs(user.token.tokenString, generationId);
+  }
+
+  @Post('generations/:generationId/trigger-configs')
+  @RequireAnyClaims(TazamaClaims.EDITOR, TazamaClaims.APPROVER)
+  @Audit()
+  @ApiParam({ name: 'generationId', description: 'Suite generation id', example: 1 })
+  @ApiBody({ type: AddTriggerTxtpConfigDto })
+  @ApiSwagger({
+    summary: 'Add trigger TXTP config (Step 3 - Add TXTP button)',
+    description:
+      'Creates a new trigger txtp config. txtp+version should match the primary TXTP (locked in UI). Uses sample payload from tcs_config as payload_template_json. Default message_count = 1.',
+    responses: mergeResponses(
+      CommonResponses.CREATED_201(TriggerConfigWithOverridesResponseDto, 'Trigger config created successfully'),
+      CommonResponses.NOT_FOUND_404('tcs_config entry not found for given txtp+version'),
+    ),
+  })
+  async addTriggerConfig(
+    @Param('generationId', ParseIntPipe) generationId: number,
+    @Body() dto: AddTriggerTxtpConfigDto,
+    @User() user: AuthenticatedUser,
+  ): Promise<TriggerConfigWithOverridesResponseDto> {
+    return await this.triggerTxtpConfigService.addTriggerConfig(user.token.tokenString, generationId, dto);
+  }
+
+  @Patch('generations/:generationId/trigger-configs')
+  @RequireAnyClaims(TazamaClaims.EDITOR, TazamaClaims.APPROVER)
+  @Audit()
+  @ApiParam({ name: 'generationId', description: 'Suite generation id', example: 1 })
+  @ApiBody({ type: [BulkTriggerConfigItemDto] })
+  @ApiSwagger({
+    summary: 'Bulk update trigger TXTP configs (Step 3 - Next button)',
+    description:
+      'Updates message_count, payload_template_json and upserts field_overrides for all provided trigger configs. Returns full updated state for the generation.',
+    responses: mergeResponses(
+      CommonResponses.SUCCESS_200(BulkUpdateTriggerConfigsResponseDto, 'Trigger configs updated successfully'),
+      CommonResponses.NOT_FOUND_404('Generation not found'),
+    ),
+  })
+  async bulkUpdateTriggerConfigs(
+    @Param('generationId', ParseIntPipe) generationId: number,
+    @Body() items: BulkTriggerConfigItemDto[],
+    @User() user: AuthenticatedUser,
+  ): Promise<BulkUpdateTriggerConfigsResponseDto> {
+    return await this.triggerTxtpConfigService.bulkUpdateTriggerConfigs(user.token.tokenString, generationId, items);
+  }
+}

--- a/backend/src/services/simulation-studio/trigger-txtp-config/trigger-txtp-config.module.ts
+++ b/backend/src/services/simulation-studio/trigger-txtp-config/trigger-txtp-config.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { AdminServiceClient } from '../../admin-service-client';
+import { TriggerTxtpConfigController } from './trigger-txtp-config.controller';
+import { TriggerTxtpConfigService } from './trigger-txtp-config.service';
+
+@Module({
+  imports: [HttpModule],
+  controllers: [TriggerTxtpConfigController],
+  providers: [TriggerTxtpConfigService, AdminServiceClient],
+  exports: [TriggerTxtpConfigService],
+})
+export class TriggerTxtpConfigModule {}

--- a/backend/src/services/simulation-studio/trigger-txtp-config/trigger-txtp-config.service.ts
+++ b/backend/src/services/simulation-studio/trigger-txtp-config/trigger-txtp-config.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { AdminServiceClient } from '../../admin-service-client';
+import type {
+  AddTriggerTxtpConfigDto,
+  TriggerConfigsListDto,
+  TriggerConfigWithOverridesResponseDto,
+  BulkTriggerConfigItemDto,
+  BulkUpdateTriggerConfigsResponseDto,
+} from './dto/trigger-txtp-config.dto';
+
+@Injectable()
+export class TriggerTxtpConfigService {
+  private readonly logger = new Logger(TriggerTxtpConfigService.name);
+
+  constructor(private readonly adminServiceClient: AdminServiceClient) {}
+
+  async getTriggerConfigs(token: string, generationId: number): Promise<TriggerConfigsListDto> {
+    try {
+      return await this.adminServiceClient.getTriggerConfigs(token, generationId);
+    } catch (err) {
+      const error = err as Error;
+      this.logger.error(`Error fetching trigger configs for generation ${generationId}`, error.stack);
+      throw err;
+    }
+  }
+
+  async addTriggerConfig(
+    token: string,
+    generationId: number,
+    dto: AddTriggerTxtpConfigDto,
+  ): Promise<TriggerConfigWithOverridesResponseDto> {
+    try {
+      return await this.adminServiceClient.addTriggerTxtpConfig(token, generationId, dto);
+    } catch (err) {
+      const error = err as Error;
+      this.logger.error(`Error adding trigger config for generation ${generationId}`, error.stack);
+      throw err;
+    }
+  }
+
+  async bulkUpdateTriggerConfigs(
+    token: string,
+    generationId: number,
+    items: BulkTriggerConfigItemDto[],
+  ): Promise<BulkUpdateTriggerConfigsResponseDto> {
+    try {
+      return await this.adminServiceClient.bulkUpdateTriggerConfigs(token, generationId, items);
+    } catch (err) {
+      const error = err as Error;
+      this.logger.error(`Error bulk updating trigger configs for generation ${generationId}`, error.stack);
+      throw err;
+    }
+  }
+}

--- a/backend/test/simulation-studio/trigger-txtp-config.service.spec.ts
+++ b/backend/test/simulation-studio/trigger-txtp-config.service.spec.ts
@@ -1,0 +1,221 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { TriggerTxtpConfigService } from '../../src/services/simulation-studio/trigger-txtp-config/trigger-txtp-config.service';
+import { AdminServiceClient } from '../../src/services/admin-service-client';
+import type {
+  AddTriggerTxtpConfigDto,
+  TriggerConfigsListDto,
+  TriggerConfigWithOverridesResponseDto,
+  BulkTriggerConfigItemDto,
+  BulkUpdateTriggerConfigsResponseDto,
+  TriggerTxtpConfigWithOverridesDto,
+} from '../../src/services/simulation-studio/trigger-txtp-config/dto/trigger-txtp-config.dto';
+
+describe('TriggerTxtpConfigService', () => {
+  let service: TriggerTxtpConfigService;
+  let adminServiceClient: jest.Mocked<AdminServiceClient>;
+
+  const mockOverride = {
+    id: 1,
+    trigger_txtp_config_id: 20,
+    field_path: 'amount',
+    override_type: 'null',
+    generator_options: {},
+    created_at: '2026-05-01T00:00:00.000Z',
+  };
+
+  const mockConfigWithOverrides: TriggerTxtpConfigWithOverridesDto = {
+    trigger_txtp_config_id: 20,
+    txtp: 'pacs.008',
+    txtp_version: '001.08',
+    message_count: 1,
+    display_order: 1,
+    payload_template_json: { amount: 100 },
+    link_to_context_pairs: false,
+    field_overrides: [mockOverride],
+  };
+
+  const mockGetResponse: TriggerConfigsListDto = {
+    success: true,
+    data: [mockConfigWithOverrides],
+  };
+
+  const mockAddResponse: TriggerConfigWithOverridesResponseDto = {
+    success: true,
+    data: mockConfigWithOverrides,
+  };
+
+  const mockBulkResponse: BulkUpdateTriggerConfigsResponseDto = {
+    success: true,
+    data: [mockConfigWithOverrides],
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TriggerTxtpConfigService,
+        {
+          provide: AdminServiceClient,
+          useValue: {
+            getTriggerConfigs: jest.fn(),
+            addTriggerTxtpConfig: jest.fn(),
+            bulkUpdateTriggerConfigs: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<TriggerTxtpConfigService>(TriggerTxtpConfigService);
+    adminServiceClient = module.get(AdminServiceClient);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // ── getTriggerConfigs ──────────────────────────────────────────────────────
+
+  describe('getTriggerConfigs', () => {
+    it('forwards token and generationId, returns configs with overrides', async () => {
+      adminServiceClient.getTriggerConfigs.mockResolvedValue(mockGetResponse);
+
+      const result = await service.getTriggerConfigs('test-token', 1);
+
+      expect(result).toEqual(mockGetResponse);
+      expect(adminServiceClient.getTriggerConfigs).toHaveBeenCalledWith('test-token', 1);
+    });
+
+    it('returns empty data array when no configs exist', async () => {
+      adminServiceClient.getTriggerConfigs.mockResolvedValue({ success: true, data: [] });
+
+      const result = await service.getTriggerConfigs('test-token', 1);
+
+      expect(result.data).toHaveLength(0);
+    });
+
+    it('logs and rethrows on error', async () => {
+      const error = new Error('Fetch failed');
+      adminServiceClient.getTriggerConfigs.mockRejectedValue(error);
+      const loggerSpy = jest.spyOn(service['logger'], 'error');
+
+      await expect(service.getTriggerConfigs('test-token', 1)).rejects.toThrow('Fetch failed');
+      expect(loggerSpy).toHaveBeenCalledWith('Error fetching trigger configs for generation 1', expect.any(String));
+    });
+  });
+
+  // ── addTriggerConfig ───────────────────────────────────────────────────────
+
+  describe('addTriggerConfig', () => {
+    it('forwards token, generationId and dto, returns config with overrides', async () => {
+      const dto: AddTriggerTxtpConfigDto = { txtp: 'pacs.008', txtp_version: '001.08', message_count: 1 };
+      adminServiceClient.addTriggerTxtpConfig.mockResolvedValue(mockAddResponse);
+
+      const result = await service.addTriggerConfig('test-token', 1, dto);
+
+      expect(result).toEqual(mockAddResponse);
+      expect(adminServiceClient.addTriggerTxtpConfig).toHaveBeenCalledWith('test-token', 1, dto);
+    });
+
+    it('defaults to message_count=1 when not provided', async () => {
+      const dto: AddTriggerTxtpConfigDto = { txtp: 'pacs.008', txtp_version: '001.08' };
+      adminServiceClient.addTriggerTxtpConfig.mockResolvedValue(mockAddResponse);
+
+      await service.addTriggerConfig('test-token', 1, dto);
+
+      expect(adminServiceClient.addTriggerTxtpConfig).toHaveBeenCalledWith('test-token', 1, dto);
+    });
+
+    it('includes field overrides seeded with null type in response', async () => {
+      const dto: AddTriggerTxtpConfigDto = { txtp: 'pacs.008', txtp_version: '001.08' };
+      adminServiceClient.addTriggerTxtpConfig.mockResolvedValue(mockAddResponse);
+
+      const result = await service.addTriggerConfig('test-token', 1, dto);
+
+      expect(result.data.field_overrides[0].override_type).toBe('null');
+    });
+
+    it('logs and rethrows on error', async () => {
+      const dto: AddTriggerTxtpConfigDto = { txtp: 'pacs.008', txtp_version: '001.08' };
+      const error = new Error('Create failed');
+      adminServiceClient.addTriggerTxtpConfig.mockRejectedValue(error);
+      const loggerSpy = jest.spyOn(service['logger'], 'error');
+
+      await expect(service.addTriggerConfig('test-token', 1, dto)).rejects.toThrow('Create failed');
+      expect(loggerSpy).toHaveBeenCalledWith('Error adding trigger config for generation 1', expect.any(String));
+    });
+  });
+
+  // ── bulkUpdateTriggerConfigs ───────────────────────────────────────────────
+
+  describe('bulkUpdateTriggerConfigs', () => {
+    it('forwards token, generationId and items array, returns updated configs', async () => {
+      const items: BulkTriggerConfigItemDto[] = [
+        {
+          trigger_txtp_config_id: 20,
+          message_count: 2,
+          field_overrides: [{ field_path: 'amount', override_type: 'static', static_value: '999' }],
+        },
+      ];
+      adminServiceClient.bulkUpdateTriggerConfigs.mockResolvedValue(mockBulkResponse);
+
+      const result = await service.bulkUpdateTriggerConfigs('test-token', 1, items);
+
+      expect(result).toEqual(mockBulkResponse);
+      expect(adminServiceClient.bulkUpdateTriggerConfigs).toHaveBeenCalledWith('test-token', 1, items);
+    });
+
+    it('handles all override types', async () => {
+      const items: BulkTriggerConfigItemDto[] = [
+        {
+          trigger_txtp_config_id: 20,
+          field_overrides: [
+            { field_path: 'field.a', override_type: 'static', static_value: 'x' },
+            { field_path: 'field.b', override_type: 'range', range_min: 1, range_max: 100 },
+            { field_path: 'field.c', override_type: 'generated', generator_type: 'iso20022.bic' },
+            { field_path: 'field.d', override_type: 'remove' },
+            { field_path: 'field.e', override_type: 'null' },
+          ],
+        },
+      ];
+      adminServiceClient.bulkUpdateTriggerConfigs.mockResolvedValue(mockBulkResponse);
+
+      await service.bulkUpdateTriggerConfigs('test-token', 1, items);
+
+      expect(adminServiceClient.bulkUpdateTriggerConfigs).toHaveBeenCalledWith('test-token', 1, items);
+    });
+
+    it('handles multiple configs in one call', async () => {
+      const items: BulkTriggerConfigItemDto[] = [
+        { trigger_txtp_config_id: 20, message_count: 2 },
+        { trigger_txtp_config_id: 21, message_count: 3, notes: 'boundary test', expected_result_band: 'bad' },
+      ];
+      adminServiceClient.bulkUpdateTriggerConfigs.mockResolvedValue(mockBulkResponse);
+
+      await service.bulkUpdateTriggerConfigs('test-token', 1, items);
+
+      expect(adminServiceClient.bulkUpdateTriggerConfigs).toHaveBeenCalledWith('test-token', 1, items);
+    });
+
+    it('supports link_to_context_pairs and expected_result_band', async () => {
+      const items: BulkTriggerConfigItemDto[] = [
+        { trigger_txtp_config_id: 20, link_to_context_pairs: true, expected_result_band: 'good' },
+      ];
+      adminServiceClient.bulkUpdateTriggerConfigs.mockResolvedValue(mockBulkResponse);
+
+      await service.bulkUpdateTriggerConfigs('test-token', 1, items);
+
+      expect(adminServiceClient.bulkUpdateTriggerConfigs).toHaveBeenCalledWith('test-token', 1, items);
+    });
+
+    it('logs and rethrows on error', async () => {
+      const error = new Error('Bulk update failed');
+      adminServiceClient.bulkUpdateTriggerConfigs.mockRejectedValue(error);
+      const loggerSpy = jest.spyOn(service['logger'], 'error');
+
+      await expect(service.bulkUpdateTriggerConfigs('test-token', 1, [])).rejects.toThrow('Bulk update failed');
+      expect(loggerSpy).toHaveBeenCalledWith('Error bulk updating trigger configs for generation 1', expect.any(String));
+    });
+  });
+});


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0
This pull request introduces a new "Trigger TXTP Config" feature to the Simulation Studio backend, enabling management of trigger transaction type configurations and their field overrides for suite generations. The changes add a new module, controller, service, DTOs, and supporting constants/methods to fully support CRUD operations for trigger configs via the API.

The most important changes are:

**API and Module Additions:**

* Added the `TriggerTxtpConfigModule`, including its controller (`trigger-txtp-config.controller.ts`) and service (`trigger-txtp-config.service.ts`), to the main application module (`app.module.ts`). This exposes new endpoints for managing trigger TXTP configs. [[1]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R24) [[2]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R50) [[3]](diffhunk://#diff-9625d87d1371372f607253945a767e19c746001b1eb6d1b4fa0d3f3865003482R1-R13) [[4]](diffhunk://#diff-5c7a6f139dff81bf0dd0fbfdc8b17cb00edd0d48579afe02d0a08567a05e6e6cR1-R86) [[5]](diffhunk://#diff-bea555ace66f02a846c95ce45fd8039e6d3a0640493468720fb833ea6a83af84R1-R54)

**DTOs and Data Contracts:**

* Defined comprehensive DTOs for trigger TXTP configs, field overrides, and bulk update operations in `generations.dto.ts`, and re-exported them for use in the new module. This standardizes request and response shapes for the new endpoints. [[1]](diffhunk://#diff-f4de1d9dbf98730a65646adf075296ee25b181a6849bc7f2dc530c795e4e22cdR349-R539) [[2]](diffhunk://#diff-e8643f1c7757a24955c54046029328fc6f0ebf9a2941ed59e76d0133694e3d9cR1-R10)

**Admin Service Client Updates:**

* Added methods to `AdminServiceClient` for getting, creating, and bulk updating trigger TXTP configs, and registered the new API endpoint constant. This enables the backend to communicate with the data layer for trigger config operations. [[1]](diffhunk://#diff-49694be9498867c5f13f9523a950a3184459e6a59699ed164e063d0df91a468eR53) [[2]](diffhunk://#diff-49694be9498867c5f13f9523a950a3184459e6a59699ed164e063d0df91a468eR582-R595) [[3]](diffhunk://#diff-e9e156d23bf4e82765e23e34d5d56ed65be36964a1cd5fdeadbefd74479dbb5fR73-R74)

These changes together provide full backend support for managing trigger TXTP configurations and their field overrides as part of the Simulation Studio workflow.
## What did we change?

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done