### PR TITLE
feat: finalized step 4 

### DIFF
--- a/frontend/src/components/SimStudio/EnrichmentData/index.tsx
+++ b/frontend/src/components/SimStudio/EnrichmentData/index.tsx
@@ -1,8 +1,10 @@
 import { type MutableRefObject } from "react";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import SaveOutlinedIcon from "@mui/icons-material/SaveOutlined";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import {
     Box,
+    IconButton,
     MenuItem,
     Select,
     Table as MuiTable,
@@ -11,6 +13,7 @@ import {
     TableHead,
     TableRow,
     TextField,
+    Tooltip,
     Typography,
 } from "@mui/material";
 import Button from "../../Button";
@@ -22,12 +25,8 @@ import useEnrichmentDataController, {
     type GenerationStrategy,
 } from "../../../hooks/SimStudio/useEnrichmentDataController";
 
-// ── Constants ─────────────────────────────────────────────────────────────────
-
 const FIELD_TYPES: SchemaFieldType[] = ["String", "Number", "Boolean", "Date", "UUID"];
 const GENERATION_STRATEGIES: GenerationStrategy[] = ["Sample Value", "Static", "Range", "Auto-generate"];
-
-// ── Schema Row ────────────────────────────────────────────────────────────────
 
 interface SchemaRowProps {
     field: SchemaField;
@@ -111,21 +110,21 @@ const SchemaRow = ({ field, onChange }: SchemaRowProps) => (
     </TableRow>
 );
 
-// ── Main Component ────────────────────────────────────────────────────────────
-
 interface EnrichmentDataProps {
     onSaveRef?: MutableRefObject<(() => Promise<boolean>) | null>;
 }
 
 const EnrichmentData = ({ onSaveRef }: EnrichmentDataProps) => {
     const { values, functions } = useEnrichmentDataController(onSaveRef);
-    const { tableName, numberOfRows, sampleJson, jsonError, schemaFields } = values;
+    const { tableName, numberOfRows, sampleJson, jsonError, schemaFields, savedRecords, isSaving, isDeleting } = values;
     const {
         setTableName,
         setNumberOfRows,
         handleSampleJsonChange,
         handleGenerateSchemaFields,
         handleFieldChange,
+        handleSaveRecord,
+        handleDeleteRecord,
     } = functions;
 
     const canGenerate = sampleJson.trim().length > 0 && !jsonError;
@@ -137,7 +136,6 @@ const EnrichmentData = ({ onSaveRef }: EnrichmentDataProps) => {
 
     return (
         <Box width="100%" maxWidth="960px">
-            {/* Info Banner */}
             <S.InfoBanner>
                 <InfoOutlinedIcon sx={{ fontSize: 18, color: "#2563eb", mt: "1px", flexShrink: 0 }} />
                 <Typography sx={{ fontSize: 13, color: "#1e40af", lineHeight: 1.6 }}>
@@ -148,8 +146,73 @@ const EnrichmentData = ({ onSaveRef }: EnrichmentDataProps) => {
                     sample record below and save it to the target table.
                 </Typography>
             </S.InfoBanner>
-
-            {/* Target Table + Rows + JSON */}
+            <S.SchemaTableContainer sx={{ mb: 2.5 }}>
+                <S.SchemaTableHeader>
+                    <Text size="body" weight="semibold">Enrichment Records</Text>
+                </S.SchemaTableHeader>
+                <MuiTable size="small">
+                    <TableHead>
+                        <TableRow>
+                            <TableCell><S.ColumnHeader>Target Table</S.ColumnHeader></TableCell>
+                            <TableCell><S.ColumnHeader>Rows</S.ColumnHeader></TableCell>
+                            <TableCell><S.ColumnHeader>Payload Preview</S.ColumnHeader></TableCell>
+                            <TableCell align="center"><S.ColumnHeader>Action</S.ColumnHeader></TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {savedRecords.length === 0 ? (
+                            <TableRow>
+                                <TableCell colSpan={4} align="center" sx={{ py: 5, color: "#9ca3af", fontSize: 13 }}>
+                                    No records to display. Add an enrichment record below.
+                                </TableCell>
+                            </TableRow>
+                        ) : (
+                            savedRecords.map((record) => (
+                                <TableRow hover key={record.enrichment_table_id}>
+                                    <TableCell sx={{ borderBottom: "1px solid #e0e0e0" }}>
+                                        <Typography sx={{ fontSize: 13, fontWeight: 500, color: "#111827" }}>
+                                            {record.table_name}
+                                        </Typography>
+                                    </TableCell>
+                                    <TableCell sx={{ borderBottom: "1px solid #e0e0e0" }}>
+                                        <Typography sx={{ fontSize: 13, color: "#374151" }}>
+                                            {record.row_count}
+                                        </Typography>
+                                    </TableCell>
+                                    <TableCell sx={{ borderBottom: "1px solid #e0e0e0", maxWidth: 320 }}>
+                                        <Typography
+                                            sx={{
+                                                fontSize: 12,
+                                                color: "#6b7280",
+                                                fontFamily: "monospace",
+                                                whiteSpace: "nowrap",
+                                                overflow: "hidden",
+                                                textOverflow: "ellipsis",
+                                            }}
+                                        >
+                                            {JSON.stringify(record.payload_template_json)}
+                                        </Typography>
+                                    </TableCell>
+                                    <TableCell align="center" sx={{ borderBottom: "1px solid #e0e0e0" }}>
+                                        <Tooltip title="Remove">
+                                            <span>
+                                                <IconButton
+                                                    size="small"
+                                                    disabled={isDeleting}
+                                                    onClick={() => { void handleDeleteRecord(record.enrichment_table_id); }}
+                                                    sx={{ color: "#ef4444", "&:hover": { backgroundColor: "#fef2f2" } }}
+                                                >
+                                                    <DeleteOutlineIcon fontSize="small" />
+                                                </IconButton>
+                                            </span>
+                                        </Tooltip>
+                                    </TableCell>
+                                </TableRow>
+                            ))
+                        )}
+                    </TableBody>
+                </MuiTable>
+            </S.SchemaTableContainer>
             <S.FormCard>
                 <Box display="flex" gap={3} flexWrap="wrap">
                     <Box flex="7 1 200px">
@@ -174,8 +237,6 @@ const EnrichmentData = ({ onSaveRef }: EnrichmentDataProps) => {
                         />
                     </Box>
                 </Box>
-
-                {/* Sample JSON */}
                 <Box mt={3}>
                     <Box display="flex" alignItems="center" justifyContent="space-between" mb={1}>
                         <S.FieldLabel sx={{ mb: 0 }}>Sample Enrichment JSON</S.FieldLabel>
@@ -214,8 +275,6 @@ const EnrichmentData = ({ onSaveRef }: EnrichmentDataProps) => {
                     )}
                 </Box>
             </S.FormCard>
-
-            {/* Configure Schema Fields */}
             <S.SchemaTableContainer>
                 <S.SchemaTableHeader>
                     <Text size="body" weight="semibold">Configure Schema Fields</Text>
@@ -249,7 +308,6 @@ const EnrichmentData = ({ onSaveRef }: EnrichmentDataProps) => {
                         )}
                     </TableBody>
                 </MuiTable>
-
                 <Box display="flex" justifyContent="flex-end" mt={2}>
                     <Button
                         height="38px"
@@ -257,7 +315,9 @@ const EnrichmentData = ({ onSaveRef }: EnrichmentDataProps) => {
                         size="md"
                         text="Save Record"
                         Icon={SaveOutlinedIcon}
-                        onClick={() => {}}
+                        loading={isSaving}
+                        disabled={!tableName.trim() || !sampleJson.trim() || !!jsonError || schemaFields.length === 0}
+                        onClick={() => { void handleSaveRecord(); }}
                     />
                 </Box>
             </S.SchemaTableContainer>

--- a/frontend/src/hooks/SimStudio/useEnrichmentDataController.tsx
+++ b/frontend/src/hooks/SimStudio/useEnrichmentDataController.tsx
@@ -1,4 +1,12 @@
 import { useCallback, useState, type MutableRefObject } from "react";
+import toast from "react-hot-toast";
+import { LocalStorage } from "../../utils/Common/enums";
+import { extractData } from "../../utils/Common/storage";
+import {
+    useGetEnrichmentTablesQuery,
+    useCreateEnrichmentTableMutation,
+    useDeleteEnrichmentTableMutation,
+} from "../../redux/Api/SimStudio";
 
 export type SchemaFieldType = "String" | "Number" | "Boolean" | "Date" | "UUID";
 export type GenerationStrategy = "Sample Value" | "Static" | "Range" | "Auto-generate";
@@ -48,6 +56,16 @@ const flattenJson = (obj: Record<string, unknown>, prefix = ""): { path: string;
 const useEnrichmentDataController = (
     onSaveRef?: MutableRefObject<(() => Promise<boolean>) | null>
 ) => {
+    const generationId = extractData("sim_gen_id", LocalStorage, false) as number | null;
+
+    const { data: enrichmentTablesData } = useGetEnrichmentTablesQuery(generationId!, {
+        skip: !generationId,
+    });
+    const [createEnrichmentTable, { isLoading: isSaving }] = useCreateEnrichmentTableMutation();
+    const [deleteEnrichmentTable, { isLoading: isDeleting }] = useDeleteEnrichmentTableMutation();
+
+    const savedRecords = enrichmentTablesData?.data ?? [];
+
     const [tableName, setTableName] = useState("");
     const [numberOfRows, setNumberOfRows] = useState(1);
     const [sampleJson, setSampleJson] = useState("");
@@ -83,7 +101,6 @@ const useEnrichmentDataController = (
             }));
             setSchemaFields(fields);
             setJsonError(null);
-            console.log("[EnrichmentData] Generated schema fields:", fields);
         } catch (e) {
             setJsonError((e as SyntaxError).message);
         }
@@ -93,34 +110,72 @@ const useEnrichmentDataController = (
         setSchemaFields((prev) => prev.map((f) => (f.id === id ? { ...f, ...changes } : f)));
     }, []);
 
-    const handleRemoveField = useCallback((id: string) => {
-        setSchemaFields((prev) => prev.filter((f) => f.id !== id));
-    }, []);
+    const handleSaveRecord = useCallback(async (): Promise<void> => {
+        if (!generationId) {
+            toast.error("Generation ID not found. Please complete Step 1 first.");
+            return;
+        }
+        if (!tableName.trim()) {
+            toast.error("Please enter a target table name.");
+            return;
+        }
+        if (!sampleJson.trim() || jsonError) {
+            toast.error("Please provide a valid sample JSON.");
+            return;
+        }
+        if (schemaFields.length === 0) {
+            toast.error("Please generate schema fields before saving.");
+            return;
+        }
+        try {
+            const payloadJson = JSON.parse(sampleJson) as Record<string, unknown>;
+            await createEnrichmentTable({
+                generationId,
+                table_name: tableName.trim(),
+                row_count: numberOfRows,
+                payload_template_json: payloadJson,
+                schema_template_json: { properties: schemaFields },
+            }).unwrap();
+            toast.success("Enrichment record saved successfully.");
+            setTableName("");
+            setNumberOfRows(1);
+            setSampleJson("");
+            setJsonError(null);
+            setSchemaFields([]);
+        } catch {
+            toast.error("Failed to save enrichment record. Please try again.");
+        }
+    }, [generationId, tableName, numberOfRows, sampleJson, jsonError, schemaFields, createEnrichmentTable]);
 
+    const handleDeleteRecord = useCallback(async (tableId: number): Promise<void> => {
+        if (!generationId) return;
+        try {
+            await deleteEnrichmentTable({ generationId, tableId }).unwrap();
+            toast.success("Enrichment record removed.");
+        } catch {
+            toast.error("Failed to remove enrichment record.");
+        }
+    }, [generationId, deleteEnrichmentTable]);
+
+    // Next button just proceeds — records are saved individually via Save Record
     const saveEnrichmentRecords = useCallback(async (): Promise<boolean> => {
-        console.log("[EnrichmentData] Saving enrichment record:", {
-            tableName,
-            numberOfRows,
-            schemaFields,
-        });
-        // TODO: wire API when ready
         return true;
-    }, [tableName, numberOfRows, schemaFields]);
+    }, []);
 
     if (onSaveRef) {
         onSaveRef.current = saveEnrichmentRecords;
     }
 
     return {
-        values: { tableName, numberOfRows, sampleJson, jsonError, schemaFields },
+        values: { tableName, numberOfRows, sampleJson, jsonError, schemaFields, savedRecords, isSaving, isDeleting },
         functions: {
             setTableName,
             setNumberOfRows,
             handleSampleJsonChange,
             handleGenerateSchemaFields,
             handleFieldChange,
-            handleRemoveField,
-            saveEnrichmentRecords,
+            handleSaveRecord,
+            handleDeleteRecord,
         },
     };
 };

--- a/frontend/src/redux/Api/SimStudio/index.ts
+++ b/frontend/src/redux/Api/SimStudio/index.ts
@@ -146,8 +146,26 @@ export interface SuitesListQuery {
     limit?: number;
 }
 
+export interface EnrichmentTableDto {
+    enrichment_table_id: number;
+    table_name: string;
+    table_order: number;
+    row_count: number;
+    payload_template_json: Record<string, unknown>;
+    schema_template_json: Record<string, unknown>;
+}
+
+export interface CreateEnrichmentTablePayload {
+    generationId: number;
+    table_name: string;
+    row_count: number;
+    payload_template_json: Record<string, unknown>;
+    schema_template_json: Record<string, unknown>;
+}
+
 export const simStudioApi = createApi({
     reducerPath: "simStudioApi",
+    tagTypes: ["EnrichmentTables"] as const,
     baseQuery: fetchBaseQuery({
         baseUrl: `${BASE_URL}/simulation-studio/`,
         prepareHeaders: (headers) => {
@@ -259,6 +277,28 @@ export const simStudioApi = createApi({
                 body: items,
             }),
         }),
+
+        getEnrichmentTables: builder.query<{ success: boolean; data: EnrichmentTableDto[] }, number>({
+            query: (generationId) => `generations/${generationId}/enrichment-tables`,
+            providesTags: ["EnrichmentTables"],
+        }),
+
+        createEnrichmentTable: builder.mutation<{ success: boolean; data: EnrichmentTableDto }, CreateEnrichmentTablePayload>({
+            query: ({ generationId, ...body }) => ({
+                url: `generations/${generationId}/enrichment-tables`,
+                method: "POST",
+                body,
+            }),
+            invalidatesTags: ["EnrichmentTables"],
+        }),
+
+        deleteEnrichmentTable: builder.mutation<{ success: boolean; message: string }, { generationId: number; tableId: number }>({
+            query: ({ generationId, tableId }) => ({
+                url: `generations/${generationId}/enrichment-tables/${tableId}`,
+                method: "DELETE",
+            }),
+            invalidatesTags: ["EnrichmentTables"],
+        }),
     }),
 });
 
@@ -276,4 +316,7 @@ export const {
     useLazyGetTriggerConfigsQuery,
     useCreateTriggerConfigMutation,
     useBulkUpdateTriggerConfigsMutation,
+    useGetEnrichmentTablesQuery,
+    useCreateEnrichmentTableMutation,
+    useDeleteEnrichmentTableMutation,
 } = simStudioApi;


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
This pull request adds full CRUD support for enrichment records in the SimStudio EnrichmentData UI. It introduces API integration for creating, listing, and deleting enrichment records, updates the UI to display and manage these records, and improves user feedback with toasts and loading states.

**API integration for enrichment records:**
- Added RTK Query endpoints and types for fetching, creating, and deleting enrichment records (`getEnrichmentTables`, `createEnrichmentTable`, `deleteEnrichmentTable`) in `frontend/src/redux/Api/SimStudio/index.ts`. [[1]](diffhunk://#diff-b8ba2dbe14f3698b266a31f8e6e3707222e66b7ce31bd0ded1c54e59648c8ccdR149-R168) [[2]](diffhunk://#diff-b8ba2dbe14f3698b266a31f8e6e3707222e66b7ce31bd0ded1c54e59648c8ccdR280-R301) [[3]](diffhunk://#diff-b8ba2dbe14f3698b266a31f8e6e3707222e66b7ce31bd0ded1c54e59648c8ccdR319-R321)

**UI enhancements for enrichment records:**
- Updated `EnrichmentData` component to display a table of saved enrichment records, with delete actions and loading/empty states, using new MUI components and icons. [[1]](diffhunk://#diff-fe4fc453cb860c7181e74660063e2c3aa52d967e17ccf2a3cdb67dbe2c7f99fdR4-R7) [[2]](diffhunk://#diff-fe4fc453cb860c7181e74660063e2c3aa52d967e17ccf2a3cdb67dbe2c7f99fdR16) [[3]](diffhunk://#diff-fe4fc453cb860c7181e74660063e2c3aa52d967e17ccf2a3cdb67dbe2c7f99fdL140) [[4]](diffhunk://#diff-fe4fc453cb860c7181e74660063e2c3aa52d967e17ccf2a3cdb67dbe2c7f99fdL151-R215)
- Integrated save and delete logic for enrichment records, including disabling/enabling buttons and showing loading indicators based on mutation state. [[1]](diffhunk://#diff-fe4fc453cb860c7181e74660063e2c3aa52d967e17ccf2a3cdb67dbe2c7f99fdL114-R127) [[2]](diffhunk://#diff-fe4fc453cb860c7181e74660063e2c3aa52d967e17ccf2a3cdb67dbe2c7f99fdL252-R320)

**Controller logic improvements:**
- Refactored `useEnrichmentDataController` to manage enrichment records state, wire up API calls, and handle errors and success with toast notifications. Added `handleSaveRecord` and `handleDeleteRecord` methods. [[1]](diffhunk://#diff-de5723165b7075694dcd7ff67a624212a4bd96b48f0755a35be47e377983aab3R2-R9) [[2]](diffhunk://#diff-de5723165b7075694dcd7ff67a624212a4bd96b48f0755a35be47e377983aab3R59-R68) [[3]](diffhunk://#diff-de5723165b7075694dcd7ff67a624212a4bd96b48f0755a35be47e377983aab3L96-R178)

**User experience improvements:**
- Added toast notifications for success and error cases when saving or deleting enrichment records, and improved form validation before saving.

These changes together provide a more robust and interactive experience for managing enrichment records in SimStudio.

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done