### PR TITLE
feat: finalize faker semantic and resume functionality.

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -22,6 +22,7 @@ import { GenerationsModule } from './services/simulation-studio/generations/gene
 import { ContextTxtpConfigModule } from './services/simulation-studio/context-txtp-config/context-txtp-config.module';
 import { TriggerTxtpConfigModule } from './services/simulation-studio/trigger-txtp-config/trigger-txtp-config.module';
 import { EnrichmentTableModule } from './services/simulation-studio/enrichment-table/enrichment-table.module';
+import { FakerSemanticDataModule } from './services/simulation-studio/faker-semantic-data/faker_semantic_data.module';
 
 @Module({
   imports: [
@@ -48,6 +49,7 @@ import { EnrichmentTableModule } from './services/simulation-studio/enrichment-t
     ContextTxtpConfigModule,
     TriggerTxtpConfigModule,
     EnrichmentTableModule,
+    FakerSemanticDataModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/constants/constant.ts
+++ b/backend/src/constants/constant.ts
@@ -84,3 +84,4 @@ export const GENERATION_CONTEXT_CONFIG = (generationId: number, configId: number
 export const GENERATION_TRIGGER_CONFIG = (generationId: number, configId: number): string =>
   `${SIMULATION_STUDIO_BASE_URL}/generations/${generationId}/trigger-configs/${configId}`;
 export const RESUME_GENERATION = (suiteId: number): string => `${SIMULATION_STUDIO_BASE_URL}/suites/${suiteId}/generation/resume`;
+export const FAKER_SYMMETRIC_DATA = `${SIMULATION_STUDIO_BASE_URL}/faker-symmetric-data`;

--- a/backend/src/constants/constant.ts
+++ b/backend/src/constants/constant.ts
@@ -84,4 +84,4 @@ export const GENERATION_CONTEXT_CONFIG = (generationId: number, configId: number
 export const GENERATION_TRIGGER_CONFIG = (generationId: number, configId: number): string =>
   `${SIMULATION_STUDIO_BASE_URL}/generations/${generationId}/trigger-configs/${configId}`;
 export const RESUME_GENERATION = (suiteId: number): string => `${SIMULATION_STUDIO_BASE_URL}/suites/${suiteId}/generation/resume`;
-export const FAKER_SYMMETRIC_DATA = `${SIMULATION_STUDIO_BASE_URL}/faker-symmetric-data`;
+export const FAKER_SEMANTIC_DATA = `${SIMULATION_STUDIO_BASE_URL}/faker-semantic-data`;

--- a/backend/src/services/admin-service-client.ts
+++ b/backend/src/services/admin-service-client.ts
@@ -63,7 +63,7 @@ import {
   GET_ALL_EVALUATIONS,
   FETCH_COUNT_DLH,
   RESUME_GENERATION,
-  FAKER_SYMMETRIC_DATA,
+  FAKER_SEMANTIC_DATA,
 } from '../constants/constant';
 import type { MaskingFiltersDto, MaskingListResponseDto, UpdateMaskDto } from './masking/dto/masking.dto';
 import type {
@@ -637,10 +637,10 @@ export class AdminServiceClient {
   }
 
   async resumeGeneration<T>(token: string, suiteId: number): Promise<T> {
-    return await this.executeHttpRequest<T>('POST', RESUME_GENERATION(suiteId), token);
+    return await this.executeHttpRequest<T>('GET', RESUME_GENERATION(suiteId), token);
   }
 
-  async generateFakerSymmetricData<T>(token: string): Promise<T> {
-    return await this.executeHttpRequest<T>('POST', FAKER_SYMMETRIC_DATA, token);
+  async generateFakerSemanticData<T>(token: string): Promise<T> {
+    return await this.executeHttpRequest<T>('GET', FAKER_SEMANTIC_DATA, token);
   }
 }

--- a/backend/src/services/admin-service-client.ts
+++ b/backend/src/services/admin-service-client.ts
@@ -63,6 +63,7 @@ import {
   GET_ALL_EVALUATIONS,
   FETCH_COUNT_DLH,
   RESUME_GENERATION,
+  FAKER_SYMMETRIC_DATA,
 } from '../constants/constant';
 import type { MaskingFiltersDto, MaskingListResponseDto, UpdateMaskDto } from './masking/dto/masking.dto';
 import type {
@@ -637,5 +638,9 @@ export class AdminServiceClient {
 
   async resumeGeneration<T>(token: string, suiteId: number): Promise<T> {
     return await this.executeHttpRequest<T>('POST', RESUME_GENERATION(suiteId), token);
+  }
+
+  async generateFakerSymmetricData<T>(token: string): Promise<T> {
+    return await this.executeHttpRequest<T>('POST', FAKER_SYMMETRIC_DATA, token);
   }
 }

--- a/backend/src/services/simulation-studio/context-txtp-config/dto/context-txtp-config.dto.ts
+++ b/backend/src/services/simulation-studio/context-txtp-config/dto/context-txtp-config.dto.ts
@@ -127,7 +127,7 @@ export class ContextFieldStrategyDto {
   range_max?: number;
 
   @ApiProperty({ required: false, example: 'iso20022.amount' })
-  generator_type?: string;
+  faker_semantic_type?: string;
 
   @ApiProperty({ required: false, example: {} })
   generator_options?: Record<string, unknown>;
@@ -210,7 +210,7 @@ export class UpsertFieldStrategyDto {
   @ApiProperty({ required: false, example: 'iso20022.bic' })
   @IsOptional()
   @IsString()
-  generator_type?: string;
+  faker_semantic_type?: string;
 
   @ApiProperty({ required: false, example: {} })
   @IsOptional()

--- a/backend/src/services/simulation-studio/faker-semantic-data/dto/faker_semantic_data.dto.ts
+++ b/backend/src/services/simulation-studio/faker-semantic-data/dto/faker_semantic_data.dto.ts
@@ -1,3 +1,5 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class FakerSemanticDataDto {
   @ApiProperty({ example: 1 })
   id: number;

--- a/backend/src/services/simulation-studio/faker-semantic-data/dto/faker_semantic_data.dto.ts
+++ b/backend/src/services/simulation-studio/faker-semantic-data/dto/faker_semantic_data.dto.ts
@@ -1,0 +1,18 @@
+export class FakerSemanticDataDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: ['name1', 'name2'] })
+  name: string[];
+}
+
+export class FakerSemanticDataListDto {
+  @ApiProperty({ example: true })
+  success: boolean;
+
+  @ApiProperty({ example: 'Data fetched successfully' })
+  message: string;
+
+  @ApiProperty({ type: [FakerSemanticDataDto] })
+  data: FakerSemanticDataDto[];
+}

--- a/backend/src/services/simulation-studio/faker-semantic-data/faker_semantic_data.controller.ts
+++ b/backend/src/services/simulation-studio/faker-semantic-data/faker_semantic_data.controller.ts
@@ -8,14 +8,14 @@ import { RequireAnyClaims, TazamaClaims } from 'src/decorators/auth.decorator';
 import type { AuthenticatedUser } from 'src/services/auth/auth.types';
 import { User } from 'src/decorators/user.decorator';
 
-@ApiTags('simulation-studio >  faker-semantic-data')
+@ApiTags('simulation-studio')
 @ApiBearerAuth('JWT-auth')
-@Controller('faker-semantic-data')
+@Controller('simulation-studio')
 @UseGuards(TazamaAuthGuard)
 export class FakerSemanticDataController {
   constructor(private readonly fakerSemanticDataService: FakerSemanticDataService) {}
 
-  @Get()
+  @Get('faker-semantic-data')
   @RequireAnyClaims(TazamaClaims.EDITOR, TazamaClaims.APPROVER)
   @ApiBearerAuth('JWT-auth')
   @ApiSwagger({

--- a/backend/src/services/simulation-studio/faker-semantic-data/faker_semantic_data.controller.ts
+++ b/backend/src/services/simulation-studio/faker-semantic-data/faker_semantic_data.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
+import { TazamaAuthGuard } from 'src/guards/tazama-auth.guard';
+import { FakerSemanticDataService } from './faker_semantic_data.service';
+import { FakerSemanticDataListDto } from './dto/faker_semantic_data.dto';
+import { ApiSwagger, CommonResponses, mergeResponses } from 'src/decorators/swagger.decorator';
+import { RequireAnyClaims, TazamaClaims } from 'src/decorators/auth.decorator';
+import type { AuthenticatedUser } from 'src/services/auth/auth.types';
+import { User } from 'src/decorators/user.decorator';
+
+@ApiTags('simulation-studio >  faker-symmetric-data')
+@ApiBearerAuth('JWT-auth')
+@Controller('faker-symmetric-data')
+@UseGuards(TazamaAuthGuard)
+export class FakerSemanticDataController {
+  constructor(private readonly fakerSemanticDataService: FakerSemanticDataService) {}
+
+  @Get()
+  @RequireAnyClaims(TazamaClaims.EDITOR, TazamaClaims.APPROVER)
+  @ApiBearerAuth('JWT-auth')
+  @ApiSwagger({
+    summary: 'Generate Faker symmetric data',
+    description: 'Generates symmetric data using Faker for testing purposes',
+    responses: mergeResponses(
+      CommonResponses.SUCCESS_200(FakerSemanticDataListDto, 'Faker symmetric data generated successfully'),
+      CommonResponses.NOT_FOUND_404('Faker symmetric data not found'),
+    ),
+  })
+  async generateFakerSymmetricData(@User() user: AuthenticatedUser): Promise<FakerSemanticDataListDto> {
+    const data = await this.fakerSemanticDataService.generateFakerSymmetricData(user.token.tokenString);
+    return data;
+  }
+}

--- a/backend/src/services/simulation-studio/faker-semantic-data/faker_semantic_data.controller.ts
+++ b/backend/src/services/simulation-studio/faker-semantic-data/faker_semantic_data.controller.ts
@@ -8,9 +8,9 @@ import { RequireAnyClaims, TazamaClaims } from 'src/decorators/auth.decorator';
 import type { AuthenticatedUser } from 'src/services/auth/auth.types';
 import { User } from 'src/decorators/user.decorator';
 
-@ApiTags('simulation-studio >  faker-symmetric-data')
+@ApiTags('simulation-studio >  faker-semantic-data')
 @ApiBearerAuth('JWT-auth')
-@Controller('faker-symmetric-data')
+@Controller('faker-semantic-data')
 @UseGuards(TazamaAuthGuard)
 export class FakerSemanticDataController {
   constructor(private readonly fakerSemanticDataService: FakerSemanticDataService) {}
@@ -19,15 +19,15 @@ export class FakerSemanticDataController {
   @RequireAnyClaims(TazamaClaims.EDITOR, TazamaClaims.APPROVER)
   @ApiBearerAuth('JWT-auth')
   @ApiSwagger({
-    summary: 'Generate Faker symmetric data',
-    description: 'Generates symmetric data using Faker for testing purposes',
+    summary: 'Generate Faker semantic data',
+    description: 'Generates semantic data using Faker for testing purposes',
     responses: mergeResponses(
-      CommonResponses.SUCCESS_200(FakerSemanticDataListDto, 'Faker symmetric data generated successfully'),
-      CommonResponses.NOT_FOUND_404('Faker symmetric data not found'),
+      CommonResponses.SUCCESS_200(FakerSemanticDataListDto, 'Faker semantic data generated successfully'),
+      CommonResponses.NOT_FOUND_404('Faker semantic data not found'),
     ),
   })
-  async generateFakerSymmetricData(@User() user: AuthenticatedUser): Promise<FakerSemanticDataListDto> {
-    const data = await this.fakerSemanticDataService.generateFakerSymmetricData(user.token.tokenString);
+  async generateFakerSemanticData(@User() user: AuthenticatedUser): Promise<FakerSemanticDataListDto> {
+    const data = await this.fakerSemanticDataService.generateFakerSemanticData(user.token.tokenString);
     return data;
   }
 }

--- a/backend/src/services/simulation-studio/faker-semantic-data/faker_semantic_data.module.ts
+++ b/backend/src/services/simulation-studio/faker-semantic-data/faker_semantic_data.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { AdminServiceClient } from '../../admin-service-client';
+import { FakerSemanticDataService } from './faker_semantic_data.service';
+import { FakerSemanticDataController } from './faker_semantic_data.controller';
+
+@Module({
+  imports: [HttpModule],
+  controllers: [FakerSemanticDataController],
+  providers: [FakerSemanticDataService, AdminServiceClient],
+  exports: [FakerSemanticDataService],
+})
+export class FakerSemanticDataModule {}

--- a/backend/src/services/simulation-studio/faker-semantic-data/faker_semantic_data.service.ts
+++ b/backend/src/services/simulation-studio/faker-semantic-data/faker_semantic_data.service.ts
@@ -1,0 +1,19 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { AdminServiceClient } from 'src/services/admin-service-client';
+import { FakerSemanticDataListDto } from './dto/faker_semantic_data.dto';
+
+@Injectable()
+export class FakerSemanticDataService {
+  private readonly logger = new Logger(FakerSemanticDataService.name);
+  constructor(private readonly adminServiceClient: AdminServiceClient) {}
+
+  async generateFakerSymmetricData(token: string): Promise<FakerSemanticDataListDto> {
+    try {
+      return await this.adminServiceClient.generateFakerSymmetricData(token);
+    } catch (err) {
+      const error = err as Error;
+      this.logger.error('Error getting faker symmetric data', error.stack);
+      throw err;
+    }
+  }
+}

--- a/backend/src/services/simulation-studio/faker-semantic-data/faker_semantic_data.service.ts
+++ b/backend/src/services/simulation-studio/faker-semantic-data/faker_semantic_data.service.ts
@@ -7,12 +7,12 @@ export class FakerSemanticDataService {
   private readonly logger = new Logger(FakerSemanticDataService.name);
   constructor(private readonly adminServiceClient: AdminServiceClient) {}
 
-  async generateFakerSymmetricData(token: string): Promise<FakerSemanticDataListDto> {
+  async generateFakerSemanticData(token: string): Promise<FakerSemanticDataListDto> {
     try {
-      return await this.adminServiceClient.generateFakerSymmetricData(token);
+      return await this.adminServiceClient.generateFakerSemanticData(token);
     } catch (err) {
       const error = err as Error;
-      this.logger.error('Error getting faker symmetric data', error.stack);
+      this.logger.error('Error getting faker semantic data', error.stack);
       throw err;
     }
   }

--- a/backend/src/services/simulation-studio/trigger-txtp-config/dto/trigger-txtp-config.dto.ts
+++ b/backend/src/services/simulation-studio/trigger-txtp-config/dto/trigger-txtp-config.dto.ts
@@ -42,7 +42,7 @@ export class TriggerFieldOverrideDto {
   range_max?: number;
 
   @ApiProperty({ required: false, example: 'iso20022.bic' })
-  generator_type?: string;
+  faker_semantic_type?: string;
 
   @ApiProperty({ required: false, example: {} })
   generator_options?: Record<string, unknown>;
@@ -77,7 +77,7 @@ export class UpsertTriggerFieldOverrideDto {
   @ApiProperty({ required: false, example: 'iso20022.bic' })
   @IsOptional()
   @IsString()
-  generator_type?: string;
+  faker_semantic_type?: string;
 
   @ApiProperty({ required: false, example: {} })
   @IsOptional()

--- a/backend/test/simulation-studio/faker-semantic-data.service.spec.ts
+++ b/backend/test/simulation-studio/faker-semantic-data.service.spec.ts
@@ -29,7 +29,7 @@ describe('FakerSemanticDataService', () => {
         {
           provide: AdminServiceClient,
           useValue: {
-            generateFakerSymmetricData: jest.fn(),
+            generateFakerSemanticData: jest.fn(),
           },
         },
       ],
@@ -43,31 +43,31 @@ describe('FakerSemanticDataService', () => {
 
   it('should be defined', () => expect(service).toBeDefined());
 
-  // ── generateFakerSymmetricData ───────────────────────────────────────────
+  // ── generateFakerSemanticData ───────────────────────────────────────────
 
-  describe('generateFakerSymmetricData', () => {
+  describe('generateFakerSemanticData', () => {
     it('forwards token to admin-service and returns the list response', async () => {
-      adminServiceClient.generateFakerSymmetricData.mockResolvedValue(mockListResponse);
+      adminServiceClient.generateFakerSemanticData.mockResolvedValue(mockListResponse);
 
-      const result = await service.generateFakerSymmetricData('test-token');
+      const result = await service.generateFakerSemanticData('test-token');
 
       expect(result).toEqual(mockListResponse);
-      expect(adminServiceClient.generateFakerSymmetricData).toHaveBeenCalledWith('test-token');
+      expect(adminServiceClient.generateFakerSemanticData).toHaveBeenCalledWith('test-token');
     });
 
     it('returns success flag and message from admin-service response', async () => {
-      adminServiceClient.generateFakerSymmetricData.mockResolvedValue(mockListResponse);
+      adminServiceClient.generateFakerSemanticData.mockResolvedValue(mockListResponse);
 
-      const result = await service.generateFakerSymmetricData('test-token');
+      const result = await service.generateFakerSemanticData('test-token');
 
       expect(result.success).toBe(true);
       expect(result.message).toBe('Data fetched successfully');
     });
 
     it('returns data array with faker items', async () => {
-      adminServiceClient.generateFakerSymmetricData.mockResolvedValue(mockListResponse);
+      adminServiceClient.generateFakerSemanticData.mockResolvedValue(mockListResponse);
 
-      const result = await service.generateFakerSymmetricData('test-token');
+      const result = await service.generateFakerSemanticData('test-token');
 
       expect(result.data).toHaveLength(1);
       expect(result.data[0].id).toBe(1);
@@ -75,24 +75,24 @@ describe('FakerSemanticDataService', () => {
     });
 
     it('returns empty data array when no faker items exist', async () => {
-      adminServiceClient.generateFakerSymmetricData.mockResolvedValue({
+      adminServiceClient.generateFakerSemanticData.mockResolvedValue({
         success: true,
         message: 'Data fetched successfully',
         data: [],
       });
 
-      const result = await service.generateFakerSymmetricData('test-token');
+      const result = await service.generateFakerSemanticData('test-token');
 
       expect(result.data).toHaveLength(0);
     });
 
     it('logs and rethrows on error', async () => {
       const error = new Error('Fetch failed');
-      adminServiceClient.generateFakerSymmetricData.mockRejectedValue(error);
+      adminServiceClient.generateFakerSemanticData.mockRejectedValue(error);
       const loggerSpy = jest.spyOn(service['logger'], 'error');
 
-      await expect(service.generateFakerSymmetricData('test-token')).rejects.toThrow('Fetch failed');
-      expect(loggerSpy).toHaveBeenCalledWith('Error getting faker symmetric data', expect.any(String));
+      await expect(service.generateFakerSemanticData('test-token')).rejects.toThrow('Fetch failed');
+      expect(loggerSpy).toHaveBeenCalledWith('Error getting faker semantic data', expect.any(String));
     });
   });
 });

--- a/backend/test/simulation-studio/faker-semantic-data.service.spec.ts
+++ b/backend/test/simulation-studio/faker-semantic-data.service.spec.ts
@@ -1,0 +1,98 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { FakerSemanticDataService } from '../../src/services/simulation-studio/faker-semantic-data/faker_semantic_data.service';
+import { AdminServiceClient } from '../../src/services/admin-service-client';
+import type {
+  FakerSemanticDataDto,
+  FakerSemanticDataListDto,
+} from '../../src/services/simulation-studio/faker-semantic-data/dto/faker_semantic_data.dto';
+
+describe('FakerSemanticDataService', () => {
+  let service: FakerSemanticDataService;
+  let adminServiceClient: jest.Mocked<AdminServiceClient>;
+
+  const mockFakerItem: FakerSemanticDataDto = {
+    id: 1,
+    name: ['name1', 'name2'],
+  };
+
+  const mockListResponse: FakerSemanticDataListDto = {
+    success: true,
+    message: 'Data fetched successfully',
+    data: [mockFakerItem],
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FakerSemanticDataService,
+        {
+          provide: AdminServiceClient,
+          useValue: {
+            generateFakerSymmetricData: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<FakerSemanticDataService>(FakerSemanticDataService);
+    adminServiceClient = module.get(AdminServiceClient);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('should be defined', () => expect(service).toBeDefined());
+
+  // ── generateFakerSymmetricData ───────────────────────────────────────────
+
+  describe('generateFakerSymmetricData', () => {
+    it('forwards token to admin-service and returns the list response', async () => {
+      adminServiceClient.generateFakerSymmetricData.mockResolvedValue(mockListResponse);
+
+      const result = await service.generateFakerSymmetricData('test-token');
+
+      expect(result).toEqual(mockListResponse);
+      expect(adminServiceClient.generateFakerSymmetricData).toHaveBeenCalledWith('test-token');
+    });
+
+    it('returns success flag and message from admin-service response', async () => {
+      adminServiceClient.generateFakerSymmetricData.mockResolvedValue(mockListResponse);
+
+      const result = await service.generateFakerSymmetricData('test-token');
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Data fetched successfully');
+    });
+
+    it('returns data array with faker items', async () => {
+      adminServiceClient.generateFakerSymmetricData.mockResolvedValue(mockListResponse);
+
+      const result = await service.generateFakerSymmetricData('test-token');
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].id).toBe(1);
+      expect(result.data[0].name).toEqual(['name1', 'name2']);
+    });
+
+    it('returns empty data array when no faker items exist', async () => {
+      adminServiceClient.generateFakerSymmetricData.mockResolvedValue({
+        success: true,
+        message: 'Data fetched successfully',
+        data: [],
+      });
+
+      const result = await service.generateFakerSymmetricData('test-token');
+
+      expect(result.data).toHaveLength(0);
+    });
+
+    it('logs and rethrows on error', async () => {
+      const error = new Error('Fetch failed');
+      adminServiceClient.generateFakerSymmetricData.mockRejectedValue(error);
+      const loggerSpy = jest.spyOn(service['logger'], 'error');
+
+      await expect(service.generateFakerSymmetricData('test-token')).rejects.toThrow('Fetch failed');
+      expect(loggerSpy).toHaveBeenCalledWith('Error getting faker symmetric data', expect.any(String));
+    });
+  });
+});

--- a/backend/test/simulation-studio/trigger-txtp-config.service.spec.ts
+++ b/backend/test/simulation-studio/trigger-txtp-config.service.spec.ts
@@ -171,11 +171,11 @@ describe('TriggerTxtpConfigService', () => {
         {
           trigger_txtp_config_id: 20,
           field_overrides: [
-            { field_path: 'field.a', override_type: 'static', static_value: 'x' },
-            { field_path: 'field.b', override_type: 'range', range_min: 1, range_max: 100 },
-            { field_path: 'field.c', override_type: 'generated', generator_type: 'iso20022.bic' },
-            { field_path: 'field.d', override_type: 'remove' },
-            { field_path: 'field.e', override_type: 'null' },
+            { field_path: 'field.a', override_type: 'static', static_value: 'x', faker_semantic_type: 'iso20022.bic' },
+            { field_path: 'field.b', override_type: 'range', range_min: 1, range_max: 100, faker_semantic_type: 'iso20022.amount' },
+            { field_path: 'field.c', override_type: 'generated', faker_semantic_type: 'iso20022.bic' },
+            { field_path: 'field.d', override_type: 'remove', faker_semantic_type: 'iso20022.bic' },
+            { field_path: 'field.e', override_type: 'null', faker_semantic_type: 'iso20022.bic' },
           ],
         },
       ];

--- a/frontend/src/components/SimStudio/EnrichmentData/index.tsx
+++ b/frontend/src/components/SimStudio/EnrichmentData/index.tsx
@@ -29,6 +29,7 @@ import useEnrichmentDataController, {
     type SchemaFieldType,
     type GenerationStrategy,
 } from "../../../hooks/SimStudio/useEnrichmentDataController";
+import { useGetFakerSemanticDataQuery } from "../../../redux/Api/SimStudio";
 
 const FIELD_TYPES: SchemaFieldType[] = ["String", "Number", "Boolean", "Date", "UUID"];
 const GENERATION_STRATEGIES: GenerationStrategy[] = ["Sample Value", "Static", "Range", "Auto-generate"];
@@ -36,9 +37,10 @@ const GENERATION_STRATEGIES: GenerationStrategy[] = ["Sample Value", "Static", "
 interface SchemaRowProps {
     field: SchemaField;
     onChange: (id: string, changes: Partial<SchemaField>) => void;
+    semanticOptions: { id: string; name: string }[];
 }
 
-const SchemaRow = ({ field, onChange }: SchemaRowProps) => (
+const SchemaRow = ({ field, onChange, semanticOptions }: SchemaRowProps) => (
     <TableRow hover>
         <TableCell sx={{ maxWidth: 220, borderBottom: "1px solid #e0e0e0" }}>
             <Typography sx={{ fontSize: 13, fontWeight: 500, color: "#2563eb", wordBreak: "break-all" }}>
@@ -112,6 +114,20 @@ const SchemaRow = ({ field, onChange }: SchemaRowProps) => (
                 <Typography sx={{ fontSize: 13, color: "#d1d5db" }}>—</Typography>
             )}
         </TableCell>
+        <TableCell sx={{ borderBottom: "1px solid #e0e0e0" }}>
+            <Select
+                size="small"
+                value={field.semanticId ?? ""}
+                displayEmpty
+                onChange={(e) => onChange(field.id, { semanticId: e.target.value })}
+                sx={{ minWidth: 140, fontSize: 13 }}
+            >
+                <MenuItem value="" sx={{ fontSize: 13, color: "#9ca3af" }}>None</MenuItem>
+                {semanticOptions.map((opt) => (
+                    <MenuItem key={opt.id} value={opt.id} sx={{ fontSize: 13 }}>{opt.name}</MenuItem>
+                ))}
+            </Select>
+        </TableCell>
     </TableRow>
 );
 
@@ -121,6 +137,8 @@ interface EnrichmentDataProps {
 
 const EnrichmentData = ({ onSaveRef }: EnrichmentDataProps) => {
     const { values, functions } = useEnrichmentDataController(onSaveRef);
+    const { data: semanticData } = useGetFakerSemanticDataQuery();
+    const semanticOptions = semanticData?.data ?? [];
     const { tableName, numberOfRows, sampleJson, jsonError, schemaFields, savedRecords, isSaving, isDeleting } = values;
     const {
         setTableName,
@@ -214,6 +232,7 @@ const EnrichmentData = ({ onSaveRef }: EnrichmentDataProps) => {
                                                 <TableCell><S.ColumnHeader>Strategy</S.ColumnHeader></TableCell>
                                                 <TableCell><S.ColumnHeader>Static Value</S.ColumnHeader></TableCell>
                                                 <TableCell><S.ColumnHeader>Range</S.ColumnHeader></TableCell>
+                                                <TableCell><S.ColumnHeader>Semantics</S.ColumnHeader></TableCell>
                                             </TableRow>
                                         </TableHead>
                                         <TableBody>
@@ -238,6 +257,13 @@ const EnrichmentData = ({ onSaveRef }: EnrichmentDataProps) => {
                                                     <TableCell sx={{ borderBottom: "1px solid #f3f4f6" }}>
                                                         <Typography sx={{ fontSize: 12, color: prop.rangeMin || prop.rangeMax ? "#374151" : "#d1d5db" }}>
                                                             {prop.rangeMin || prop.rangeMax ? `${prop.rangeMin} – ${prop.rangeMax}` : "—"}
+                                                        </Typography>
+                                                    </TableCell>
+                                                    <TableCell sx={{ borderBottom: "1px solid #f3f4f6" }}>
+                                                        <Typography sx={{ fontSize: 12, color: prop.semanticId ? "#374151" : "#d1d5db" }}>
+                                                            {prop.semanticId
+                                                                ? (semanticOptions.find((s) => s.id === prop.semanticId)?.name ?? prop.semanticId)
+                                                                : "—"}
                                                         </Typography>
                                                     </TableCell>
                                                 </TableRow>
@@ -325,12 +351,13 @@ const EnrichmentData = ({ onSaveRef }: EnrichmentDataProps) => {
                             <TableCell><S.ColumnHeader>Generation Strategy</S.ColumnHeader></TableCell>
                             <TableCell><S.ColumnHeader>Static Value</S.ColumnHeader></TableCell>
                             <TableCell><S.ColumnHeader>Range</S.ColumnHeader></TableCell>
+                            <TableCell><S.ColumnHeader>Semantics</S.ColumnHeader></TableCell>
                         </TableRow>
                     </TableHead>
                     <TableBody>
                         {schemaFields.length === 0 ? (
                             <TableRow>
-                                <TableCell colSpan={5} align="center" sx={{ py: 5, color: "#9ca3af", fontSize: 13 }}>
+                                <TableCell colSpan={6} align="center" sx={{ py: 5, color: "#9ca3af", fontSize: 13 }}>
                                     Paste a JSON sample above and click <strong>Generate Schema Fields</strong>.
                                 </TableCell>
                             </TableRow>
@@ -340,6 +367,7 @@ const EnrichmentData = ({ onSaveRef }: EnrichmentDataProps) => {
                                     key={field.id}
                                     field={field}
                                     onChange={handleFieldChange}
+                                    semanticOptions={semanticOptions}
                                 />
                             ))
                         )}

--- a/frontend/src/components/SimStudio/RuleDetails/index.tsx
+++ b/frontend/src/components/SimStudio/RuleDetails/index.tsx
@@ -10,6 +10,7 @@ import Input from "../../Input";
 import Loader from "../../Loader";
 import * as S from "../../../pages/SimStudio/CreateSimSuite/CreateSimSuite.styles";
 import type { Step1Values } from "../../../hooks/SimStudio/useCreateSimSuiteController";
+import type { SuiteDetail } from "../../../redux/Api/SimStudio";
 
 interface Step1Props {
     control: Control<Step1Values>;
@@ -20,6 +21,8 @@ interface Step1Props {
     ruleVersionOptions: DropdownOption[];
     txLoading: boolean;
     versionLoading: boolean;
+    existingSuite?: SuiteDetail | null;
+    isSuiteLoading?: boolean;
 }
 
 const Step1RuleDetails = ({
@@ -31,8 +34,12 @@ const Step1RuleDetails = ({
     ruleVersionOptions,
     txLoading,
     versionLoading,
+    existingSuite,
+    isSuiteLoading,
 }: Step1Props) => {
-    if (txLoading) return <Loader center />;
+    if (txLoading || isSuiteLoading) return <Loader center />;
+
+    const isDisabled = !!existingSuite;
 
     return (
         <Box width="100%" maxWidth="700px" display="flex" flexDirection="column">
@@ -55,6 +62,7 @@ const Step1RuleDetails = ({
                                     label="Simulation Suite Name"
                                     placeholder="e.g., Q3 Edge Cases"
                                     {...field}
+                                    disabled={isDisabled}
                                     error={errors.suite_name?.message}
                                 />
                             )}
@@ -72,6 +80,7 @@ const Step1RuleDetails = ({
                                     label="Description"
                                     placeholder="Describe the purpose of this simulation suite..."
                                     {...field}
+                                    disabled={isDisabled}
                                 />
                             )}
                         />
@@ -87,6 +96,7 @@ const Step1RuleDetails = ({
                                     options={ruleOptions}
                                     value={field.value ?? null}
                                     onChange={(val) => field.onChange(val)}
+                                    disabled={isDisabled}
                                     error={errors.associated_rule?.message as string | undefined}
                                 />
                             )}
@@ -103,7 +113,7 @@ const Step1RuleDetails = ({
                                     options={ruleVersionOptions}
                                     value={field.value ?? null}
                                     onChange={(val) => field.onChange(val)}
-                                    disabled={ruleVersionOptions.length === 0}
+                                    disabled={isDisabled || ruleVersionOptions.length === 0}
                                     error={error?.message}
                                 />
                             )}
@@ -122,6 +132,7 @@ const Step1RuleDetails = ({
                                     searchable
                                     value={field.value ?? null}
                                     onChange={(val) => field.onChange(val)}
+                                    disabled={isDisabled}
                                     error={errors.txtp?.message as string | undefined}
                                 />
                             )}
@@ -139,7 +150,7 @@ const Step1RuleDetails = ({
                                     options={versionOptions}
                                     value={field.value ?? null}
                                     onChange={(val) => field.onChange(val)}
-                                    disabled={versionOptions.length === 0 || versionLoading}
+                                    disabled={isDisabled || versionOptions.length === 0 || versionLoading}
                                     error={errors.version?.message as string | undefined}
                                 />
                             )}
@@ -208,6 +219,7 @@ const Step1RuleDetails = ({
                                             multiline
                                             minRows={8}
                                             maxRows={20}
+                                            disabled={isDisabled}
                                             value={field.value === "{}" ? "" : (field.value ?? "")}
                                             onChange={(e) => handleChange(e.target.value)}
                                             placeholder={'Enter Rule Config here...\n{\n  "key": "value"\n}'}
@@ -241,3 +253,4 @@ const Step1RuleDetails = ({
 };
 
 export default Step1RuleDetails;
+

--- a/frontend/src/components/SimStudio/TriggerData/index.tsx
+++ b/frontend/src/components/SimStudio/TriggerData/index.tsx
@@ -27,6 +27,7 @@ import useTriggerDataController, {
   type TriggerOverride,
   type TriggerOverrideType,
 } from "../../../hooks/SimStudio/useTriggerDataController";
+import { useGetFakerSemanticDataQuery } from "../../../redux/Api/SimStudio";
 
 const OVERRIDE_OPTIONS: { label: string; value: TriggerOverrideType }[] = [
   { label: "No Override", value: "null" },
@@ -41,11 +42,12 @@ const OVERRIDE_OPTIONS: { label: string; value: TriggerOverrideType }[] = [
 interface FieldOverridesTableProps {
   entry: TriggerEntry;
   onOverrideChange: (entryId: string, fieldPath: string, override: TriggerOverride) => void;
+  semanticOptions: { id: string; name: string }[];
 }
 
-const FieldOverridesTable = ({ entry, onOverrideChange }: FieldOverridesTableProps) => {
+const FieldOverridesTable = ({ entry, onOverrideChange, semanticOptions }: FieldOverridesTableProps) => {
   const getOverride = (path: string): TriggerOverride =>
-    entry.fieldOverrides[path] ?? { overrideType: "null", staticValue: "", rangeMin: "", rangeMax: "" };
+    entry.fieldOverrides[path] ?? { overrideType: "null", staticValue: "", rangeMin: "", rangeMax: "", semanticId: "" };
 
   return (
     <S.FieldConfigSection>
@@ -63,12 +65,13 @@ const FieldOverridesTable = ({ entry, onOverrideChange }: FieldOverridesTablePro
               <TableCell sx={{ fontWeight: 600, fontSize: "12px", bgcolor: "#fbf9fa", width: "20%" }}>Override Type</TableCell>
               <TableCell sx={{ fontWeight: 600, fontSize: "12px", bgcolor: "#fbf9fa", width: "22%" }}>Static Value</TableCell>
               <TableCell sx={{ fontWeight: 600, fontSize: "12px", bgcolor: "#fbf9fa" }}>Range</TableCell>
+              <TableCell sx={{ fontWeight: 600, fontSize: "12px", bgcolor: "#fbf9fa", width: "18%" }}>Semantics</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             {entry.payloadFields.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={4} align="center" sx={{ py: 3, color: "#9ca3af" }}>
+                <TableCell colSpan={5} align="center" sx={{ py: 3, color: "#9ca3af" }}>
                   No fields available from payload
                 </TableCell>
               </TableRow>
@@ -95,6 +98,7 @@ const FieldOverridesTable = ({ entry, onOverrideChange }: FieldOverridesTablePro
                             staticValue: newType === "static" ? override.staticValue : "",
                             rangeMin: newType === "range" ? override.rangeMin : "",
                             rangeMax: newType === "range" ? override.rangeMax : "",
+                            semanticId: override.semanticId,
                           });
                         }}
                         sx={{ fontSize: "12px", minWidth: 160, "& .MuiSelect-select": { py: "4px" } }}
@@ -142,6 +146,22 @@ const FieldOverridesTable = ({ entry, onOverrideChange }: FieldOverridesTablePro
                         <Typography sx={{ fontSize: "12px", color: "#d1d5db" }}>—</Typography>
                       )}
                     </TableCell>
+                    <TableCell sx={{ borderBottom: "1px solid #e0e0e0" }}>
+                      <Select
+                        value={override.semanticId ?? ""}
+                        size="small"
+                        displayEmpty
+                        onChange={(e) => onOverrideChange(entry.id, path, { ...override, semanticId: e.target.value })}
+                        sx={{ fontSize: "12px", minWidth: 140, "& .MuiSelect-select": { py: "4px" } }}
+                      >
+                        <MenuItem value="" sx={{ fontSize: "12px", color: "#9ca3af" }}>None</MenuItem>
+                        {semanticOptions.map((opt) => (
+                          <MenuItem key={opt.id} value={opt.id} sx={{ fontSize: "12px" }}>
+                            {opt.name}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </TableCell>
                   </TableRow>
                 );
               })
@@ -162,6 +182,7 @@ interface EntryRowProps {
   onRemove: (id: string) => void;
   onNumMessagesChange: (id: string, value: number) => void;
   onOverrideChange: (entryId: string, fieldPath: string, override: TriggerOverride) => void;
+  semanticOptions: { id: string; name: string }[];
 }
 
 const EntryRow = ({
@@ -171,6 +192,7 @@ const EntryRow = ({
   onRemove,
   onNumMessagesChange,
   onOverrideChange,
+  semanticOptions,
 }: EntryRowProps) => (
   <>
     <TableRow hover sx={{ bgcolor: "#fff" }}>
@@ -217,7 +239,7 @@ const EntryRow = ({
     <TableRow>
       <TableCell colSpan={6} sx={{ p: 0, borderBottom: entry.expanded ? "1px solid #e0e0e0" : "none" }}>
         <Collapse in={entry.expanded} timeout="auto" unmountOnExit>
-          <FieldOverridesTable entry={entry} onOverrideChange={onOverrideChange} />
+          <FieldOverridesTable entry={entry} onOverrideChange={onOverrideChange} semanticOptions={semanticOptions} />
         </Collapse>
       </TableCell>
     </TableRow>
@@ -232,6 +254,8 @@ interface TriggerDataProps {
 
 const TriggerData = ({ onSaveRef }: TriggerDataProps) => {
   const { values, functions } = useTriggerDataController();
+  const { data: semanticData } = useGetFakerSemanticDataQuery();
+  const semanticOptions = semanticData?.data ?? [];
   const { entries, numMessages, adding, primaryTxtp } = values;
   const {
     setNumMessages,
@@ -349,6 +373,7 @@ const TriggerData = ({ onSaveRef }: TriggerDataProps) => {
                   onRemove={handleRemove}
                   onNumMessagesChange={handleNumMessagesChange}
                   onOverrideChange={handleOverrideChange}
+                  semanticOptions={semanticOptions}
                 />
               ))
             )}

--- a/frontend/src/components/SimStudio/TxtpSelection/index.tsx
+++ b/frontend/src/components/SimStudio/TxtpSelection/index.tsx
@@ -27,11 +27,13 @@ import useTxtpSelectionController, {
     type FieldConfig,
     type TxtpEntry,
 } from "../../../hooks/SimStudio/useTxtpSelectionController";
+import { useGetFakerSemanticDataQuery } from "../../../redux/Api/SimStudio";
 import * as S from "./TxtpSelection.styles";
 
 interface FieldConfigTableProps {
     entry: TxtpEntry;
     onFieldConfigChange: (entryId: string, path: string, config: FieldConfig) => void;
+    semanticOptions: { id: string; name: string }[];
 }
 
 interface EntryRowProps {
@@ -42,6 +44,7 @@ interface EntryRowProps {
     onRemove: (id: string) => void;
     onNumMessagesChange: (id: string, value: number) => void;
     onFieldConfigChange: (entryId: string, path: string, config: FieldConfig) => void;
+    semanticOptions: { id: string; name: string }[];
 }
 
 const FIELD_ACTION_OPTIONS: { label: string; value: FieldAction }[] = [
@@ -51,9 +54,9 @@ const FIELD_ACTION_OPTIONS: { label: string; value: FieldAction }[] = [
     { label: "Skip Field", value: "skip" },
 ];
 
-const FieldConfigTable = ({ entry, onFieldConfigChange }: FieldConfigTableProps) => {
+const FieldConfigTable = ({ entry, onFieldConfigChange, semanticOptions }: FieldConfigTableProps) => {
     const getConfig = (path: string): FieldConfig =>
-        entry.fieldConfigs[path] ?? { action: "sample", staticValue: "", rangeStart: "", rangeEnd: "" };
+        entry.fieldConfigs[path] ?? { action: "sample", staticValue: "", rangeStart: "", rangeEnd: "", semanticId: "" };
 
     return (
         <S.FieldConfigSection>
@@ -100,12 +103,17 @@ const FieldConfigTable = ({ entry, onFieldConfigChange }: FieldConfigTableProps)
                             >
                                 Range
                             </TableCell>
+                            <TableCell
+                                sx={{ fontWeight: 600, fontSize: "12px", bgcolor: "#fbf9fa", width: "18%" }}
+                            >
+                                Semantics
+                            </TableCell>
                         </TableRow>
                     </TableHead>
                     <TableBody>
                         {entry.fieldPaths.length === 0 ? (
                             <TableRow>
-                                <TableCell colSpan={4} align="center" sx={{ py: 3, color: "#9ca3af" }}>
+                                <TableCell colSpan={5} align="center" sx={{ py: 3, color: "#9ca3af" }}>
                                     No fields available from payload
                                 </TableCell>
                             </TableRow>
@@ -148,6 +156,7 @@ const FieldConfigTable = ({ entry, onFieldConfigChange }: FieldConfigTableProps)
                                                         staticValue: newAction === "static" ? config.staticValue : "",
                                                         rangeStart: newAction === "range" ? config.rangeStart : "",
                                                         rangeEnd: newAction === "range" ? config.rangeEnd : "",
+                                                        semanticId: config.semanticId,
                                                     });
                                                 }}
                                                 sx={{
@@ -214,6 +223,27 @@ const FieldConfigTable = ({ entry, onFieldConfigChange }: FieldConfigTableProps)
                                                 <Typography sx={{ fontSize: "12px", color: "#d1d5db" }}>—</Typography>
                                             )}
                                         </TableCell>
+                                        <TableCell sx={{ borderBottom: "1px solid #e0e0e0" }}>
+                                            <Select
+                                                value={config.semanticId ?? ""}
+                                                size="small"
+                                                displayEmpty
+                                                onChange={(e) =>
+                                                    onFieldConfigChange(entry.id, path, {
+                                                        ...config,
+                                                        semanticId: e.target.value,
+                                                    })
+                                                }
+                                                sx={{ fontSize: "12px", minWidth: 140, "& .MuiSelect-select": { py: "4px" } }}
+                                            >
+                                                <MenuItem value="" sx={{ fontSize: "12px", color: "#9ca3af" }}>None</MenuItem>
+                                                {semanticOptions.map((opt) => (
+                                                    <MenuItem key={opt.id} value={opt.id} sx={{ fontSize: "12px" }}>
+                                                        {opt.name}
+                                                    </MenuItem>
+                                                ))}
+                                            </Select>
+                                        </TableCell>
                                     </TableRow>
                                 );
                             })
@@ -233,6 +263,7 @@ const EntryRow = ({
     onRemove,
     onNumMessagesChange,
     onFieldConfigChange,
+    semanticOptions,
 }: EntryRowProps) => (
     <>
         <TableRow hover sx={{ bgcolor: "#fff" }}>
@@ -286,6 +317,7 @@ const EntryRow = ({
                     <FieldConfigTable
                         entry={entry}
                         onFieldConfigChange={onFieldConfigChange}
+                        semanticOptions={semanticOptions}
                     />
                 </Collapse>
             </TableCell>
@@ -299,6 +331,8 @@ interface TxtpSelectionProps {
 
 const TxtpSelection = ({ onSaveRef }: TxtpSelectionProps) => {
     const { values, functions } = useTxtpSelectionController();
+    const { data: semanticData } = useGetFakerSemanticDataQuery();
+    const semanticOptions = semanticData?.data ?? [];
 
     const {
         entries,
@@ -438,6 +472,7 @@ const TxtpSelection = ({ onSaveRef }: TxtpSelectionProps) => {
                                     onRemove={handleRemove}
                                     onNumMessagesChange={handleNumMessagesChange}
                                     onFieldConfigChange={handleFieldConfigChange}
+                                    semanticOptions={semanticOptions}
                                 />
                             ))
                         )}

--- a/frontend/src/contexts/SimStudioTabContext/SimStudioTabProvider.tsx
+++ b/frontend/src/contexts/SimStudioTabContext/SimStudioTabProvider.tsx
@@ -11,7 +11,15 @@ export const SimStudioTabProvider = ({ children }: SimStudioTabProviderProps) =>
     const [searchParams, setSearchParams] = useSearchParams()
     const tabFromUrl = searchParams.get('simStudioTab') ?? SimStudioTabs[0].value
     const [selectedTab, setSelectedTabState] = useState<string>(tabFromUrl)
-    const [enabledTabs, setEnabledTabs] = useState<string[]>([SimStudioTabs[0].value])
+
+    const getInitialEnabledTabs = (): string[] => {
+        const targetIdx = SimStudioTabs.findIndex(t => t.value === tabFromUrl)
+        if (targetIdx > 0) {
+            return SimStudioTabs.slice(0, targetIdx + 1).map(t => t.value)
+        }
+        return [SimStudioTabs[0].value]
+    }
+    const [enabledTabs, setEnabledTabs] = useState<string[]>(getInitialEnabledTabs)
     const filteredTabs = useMemo(() => SimStudioTabs, [])
 
     const handleSetSelectedTab = useCallback((tab: string) => {

--- a/frontend/src/hooks/SimStudio/useCreateSimSuiteController.tsx
+++ b/frontend/src/hooks/SimStudio/useCreateSimSuiteController.tsx
@@ -7,7 +7,7 @@ import * as yup from "yup";
 import type { DropdownOption } from "../../components/DropDown";
 import { useSimStudioTab } from "../../contexts/SimStudioTabContext";
 import { useGetTypesQuery, useLazyGetTxtpVersionsQuery } from "../../redux/Api/Config";
-import { useCreateSuiteMutation, useUpdateWizardProgressMutation } from "../../redux/Api/SimStudio";
+import { useCreateSuiteMutation, useUpdateWizardProgressMutation, useLazyGetSuiteByIdQuery } from "../../redux/Api/SimStudio";
 import { useGetRulesQuery, useLazyGetRuleTagsQuery } from "../../redux/Api/DockerHub";
 import { LocalStorage } from "../../utils/Common/enums";
 import { insertData, extractData } from "../../utils/Common/storage";
@@ -75,6 +75,47 @@ const useCreateSimSuiteController = () => {
         const genId = extractData("sim_gen_id", LocalStorage, false) as string | number | null;
         return genId ? Number(genId) : null;
     }, []);
+
+    const extractSuiteId = useCallback(() => {
+        const suiteId = extractData("sim_suite_id", LocalStorage, false) as string | number | null;
+        return suiteId ? Number(suiteId) : null;
+    }, []);
+
+    const [getSuiteById, { data: existingSuiteData, isFetching: isSuiteLoading }] = useLazyGetSuiteByIdQuery();
+
+    useEffect(() => {
+        if (selectedTab === SimStudioTabs[0].value) {
+            const suiteId = extractSuiteId();
+            if (suiteId) void getSuiteById(suiteId);
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selectedTab]);
+
+    const existingSuite = existingSuiteData?.suite ?? null;
+
+    useEffect(() => {
+        if (!existingSuite) return;
+        reset({
+            suite_name: existingSuite.name ?? "",
+            description: existingSuite.description ?? "",
+            associated_rule: existingSuite.rule_name
+                ? { label: existingSuite.rule_name, value: existingSuite.rule_name }
+                : null,
+            rule_version: existingSuite.rule_version
+                ? { label: existingSuite.rule_version, value: existingSuite.rule_version }
+                : null,
+            txtp: existingSuite.primary_txtp
+                ? { label: existingSuite.primary_txtp, value: existingSuite.primary_txtp }
+                : null,
+            version: existingSuite.primary_txtp_version
+                ? { label: existingSuite.primary_txtp_version, value: existingSuite.primary_txtp_version }
+                : null,
+            rule_config: existingSuite.rule_config
+                ? JSON.stringify(existingSuite.rule_config, null, 2)
+                : "{}",
+        });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [existingSuite]);
     const { data: rulesData } = useGetRulesQuery();
     const [getRuleTags, { data: ruleTagsData }] = useLazyGetRuleTagsQuery();
     const step2SaveRef = useRef<(() => Promise<boolean>) | null>(null);
@@ -86,6 +127,7 @@ const useCreateSimSuiteController = () => {
         handleSubmit,
         watch,
         setValue,
+        reset,
         formState: { errors },
     } = useForm<Step1Values>({
         resolver: yupResolver(step1Schema) as never,
@@ -164,6 +206,10 @@ const useCreateSimSuiteController = () => {
 
     const handleNextStep = () => {
         if (selectedTab === SimStudioTabs[0].value) {
+            if (existingSuite) {
+                enableNextTab();
+                return;
+            }
             void handleSubmit(async (data) => {
                 try {
                     let parsedRuleConfig: Record<string, unknown>;
@@ -178,7 +224,9 @@ const useCreateSimSuiteController = () => {
                         rule_config: parsedRuleConfig,
                     }).unwrap();
                     const genId = result.data.generation_id as unknown as number;
+                    const suiteId = result.data.id as unknown as number;
                     insertData(genId, "sim_gen_id", LocalStorage, false);
+                    insertData(suiteId, "sim_suite_id", LocalStorage, false);
                     void updateWizardProgress({ generationId: genId, current_step_num: 2, completed_step_num: 1 });
                     enableNextTab();
                 } catch {
@@ -222,7 +270,7 @@ const useCreateSimSuiteController = () => {
 
     const renderStep = () => {
         switch (selectedTab) {
-            case 'rule_details':
+            case 'create_generation':
                 return (
                     <Step1RuleDetails
                         control={control}
@@ -233,6 +281,8 @@ const useCreateSimSuiteController = () => {
                         ruleVersionOptions={ruleVersionOptions}
                         txLoading={txLoading}
                         versionLoading={versionLoading}
+                        existingSuite={existingSuite}
+                        isSuiteLoading={isSuiteLoading}
                     />
                 );
             case 'txtp_selection':      return <TxtpSelection onSaveRef={step2SaveRef} />;
@@ -246,9 +296,10 @@ const useCreateSimSuiteController = () => {
     };
 
     const currentStepIndex = tabs.findIndex(t => t.value === selectedTab);
+    const isStep1ReadOnly = selectedTab === SimStudioTabs[0].value && existingSuite !== null;
 
     return {
-        values: { currentStepIndex, totalSteps: tabs.length, isCreatingSuite, selectedTab },
+        values: { currentStepIndex, totalSteps: tabs.length, isCreatingSuite, selectedTab, isStep1ReadOnly },
         functions: { handleBack, handleNextStep, renderStep },
     };
 };

--- a/frontend/src/hooks/SimStudio/useEnrichmentDataController.tsx
+++ b/frontend/src/hooks/SimStudio/useEnrichmentDataController.tsx
@@ -19,6 +19,7 @@ export interface SchemaField {
     staticValue: string;
     rangeMin: string;
     rangeMax: string;
+    semanticId: string;
 }
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}/;
@@ -98,6 +99,7 @@ const useEnrichmentDataController = (
                 staticValue: "",
                 rangeMin: "",
                 rangeMax: "",
+                semanticId: "",
             }));
             setSchemaFields(fields);
             setJsonError(null);

--- a/frontend/src/hooks/SimStudio/useTriggerDataController.tsx
+++ b/frontend/src/hooks/SimStudio/useTriggerDataController.tsx
@@ -18,6 +18,7 @@ export interface TriggerOverride {
     staticValue: string;
     rangeMin: string;
     rangeMax: string;
+    semanticId: string;
 }
 
 export interface TriggerEntry {
@@ -59,6 +60,7 @@ const buildTriggerEntry = (cfg: TriggerTxtpConfig): TriggerEntry => {
             staticValue: o.static_value != null ? String(o.static_value) : "",
             rangeMin: o.range_min != null ? String(o.range_min) : "",
             rangeMax: o.range_max != null ? String(o.range_max) : "",
+            semanticId: o.faker_semantic_type ?? "",
         };
     }
 
@@ -200,6 +202,7 @@ const useTriggerDataController = () => {
                     static_value: o.overrideType === "static" ? o.staticValue : undefined,
                     range_min: o.overrideType === "range" && o.rangeMin ? Number(o.rangeMin) : undefined,
                     range_max: o.overrideType === "range" && o.rangeMax ? Number(o.rangeMax) : undefined,
+                    faker_semantic_type: o.semanticId || undefined,
                 })),
             }));
 

--- a/frontend/src/hooks/SimStudio/useTxtpSelectionController.tsx
+++ b/frontend/src/hooks/SimStudio/useTxtpSelectionController.tsx
@@ -23,6 +23,7 @@ export interface FieldConfig {
     staticValue: string;
     rangeStart: string;
     rangeEnd: string;
+    semanticId: string;
 }
 
 export interface TxtpEntry {
@@ -100,6 +101,7 @@ const buildEntryFromContextConfig = (cfg: {
             staticValue: s.static_value != null ? String(s.static_value) : "",
             rangeStart: s.range_min != null ? String(s.range_min) : "",
             rangeEnd: s.range_max != null ? String(s.range_max) : "",
+            semanticId: s.faker_semantic_type ?? "",
         };
     }
     return {
@@ -199,18 +201,19 @@ const useTxtpSelectionController = () => {
                 field_strategies: Object.entries(entry.fieldConfigs).map(([fieldPath, cfg]) => {
                     switch (cfg.action) {
                         case "static":
-                            return { field_path: fieldPath, strategy_code: "static" as const, static_value: cfg.staticValue };
+                            return { field_path: fieldPath, strategy_code: "static" as const, static_value: cfg.staticValue, faker_semantic_type: cfg.semanticId || undefined };
                         case "range":
                             return {
                                 field_path: fieldPath,
                                 strategy_code: "range" as const,
                                 range_min: cfg.rangeStart ? Number(cfg.rangeStart) : undefined,
                                 range_max: cfg.rangeEnd ? Number(cfg.rangeEnd) : undefined,
+                                faker_semantic_type: cfg.semanticId || undefined,
                             };
                         case "skip":
-                            return { field_path: fieldPath, strategy_code: "skip" as const };
+                            return { field_path: fieldPath, strategy_code: "skip" as const, faker_semantic_type: cfg.semanticId || undefined };
                         default:
-                            return { field_path: fieldPath, strategy_code: "keep_sample" as const };
+                            return { field_path: fieldPath, strategy_code: "keep_sample" as const, faker_semantic_type: cfg.semanticId || undefined };
                     }
                 }),
             }));

--- a/frontend/src/pages/SimStudio/SimStudioActions.tsx
+++ b/frontend/src/pages/SimStudio/SimStudioActions.tsx
@@ -1,18 +1,42 @@
+import PlayCircleOutlineIcon from "@mui/icons-material/PlayCircleOutline";
 import VisibilityOutlinedIcon from "@mui/icons-material/VisibilityOutlined";
-import { IconButton, Tooltip } from "@mui/material";
+import { Box, CircularProgress, IconButton, Tooltip } from "@mui/material";
 import { memo } from "react";
 
 interface SimStudioActionsProps {
     onView: () => void;
+    onResume?: () => void;
+    isDraft?: boolean;
+    isResuming?: boolean;
 }
 
-const SimStudioActions = ({ onView }: SimStudioActionsProps) => {
+const SimStudioActions = ({ onView, onResume, isDraft, isResuming }: SimStudioActionsProps) => {
     return (
-        <Tooltip title="View">
-            <IconButton size="small" sx={{ color: "text.ternary" }} onClick={onView}>
-                <VisibilityOutlinedIcon fontSize="small" />
-            </IconButton>
-        </Tooltip>
+        <Box display="flex" alignItems="center" gap={0.5}>
+            {isDraft && (
+                <Tooltip title="Resume">
+                    <span>
+                        <IconButton
+                            size="small"
+                            sx={{ color: "#f59e0b" }}
+                            onClick={onResume}
+                            disabled={isResuming}
+                        >
+                            {isResuming ? (
+                                <CircularProgress size={16} sx={{ color: "#f59e0b" }} />
+                            ) : (
+                                <PlayCircleOutlineIcon fontSize="small" />
+                            )}
+                        </IconButton>
+                    </span>
+                </Tooltip>
+            )}
+            <Tooltip title="View">
+                <IconButton size="small" sx={{ color: "text.ternary" }} onClick={onView}>
+                    <VisibilityOutlinedIcon fontSize="small" />
+                </IconButton>
+            </Tooltip>
+        </Box>
     );
 };
 

--- a/frontend/src/pages/SimStudio/useSimStudioController.tsx
+++ b/frontend/src/pages/SimStudio/useSimStudioController.tsx
@@ -1,11 +1,14 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import toast from "react-hot-toast";
 import StatusCard from "../../components/Cards/StatusCard";
 import type { TableColumn } from "../../components/Table";
 import useDebouncedSearch from "../../hooks/useDebouncedSearch";
-import { useGetSuitesQuery, type SuiteListItem } from "../../redux/Api/SimStudio";
+import { useGetSuitesQuery, useLazyResumeGenerationQuery, type SuiteListItem } from "../../redux/Api/SimStudio";
 import { useGetRulesQuery } from "../../redux/Api/DockerHub";
 import { useGetTypesQuery } from "../../redux/Api/Config";
+import { LocalStorage } from "../../utils/Common/enums";
+import { insertData, removeData } from "../../utils/Common/storage";
 import * as S from "./SimStudio.styles";
 import SimStudioActions from "./SimStudioActions";
 
@@ -31,6 +34,15 @@ const useSimStudioController = () => {
     const [lastUpdatedFrom, setLastUpdatedFrom] = useState<string>("");
     const [lastUpdatedTo, setLastUpdatedTo] = useState<string>("");
     const [page, setPage] = useState(0);
+    const [resumingId, setResumingId] = useState<number | null>(null);
+
+    const STEP_TAB_MAP: Record<number, string> = {
+        1: "create_generation",
+        2: "txtp_selection",
+        3: "trigger_data",
+        4: "enrichment_data",
+        5: "preview_save",
+    };
 
     const LIMIT = 10;
 
@@ -50,6 +62,7 @@ const useSimStudioController = () => {
     const { data, isLoading, isFetching } = useGetSuitesQuery(queryParams);
     const { data: rulesData } = useGetRulesQuery();
     const { data: txTypesData } = useGetTypesQuery({});
+    const [triggerResume] = useLazyResumeGenerationQuery();
 
     const suites: SuiteListItem[] = data?.suites ?? [];
 
@@ -118,6 +131,23 @@ const useSimStudioController = () => {
         navigate(`/sim-studio/view/${row.id}`);
     }, [navigate]);
 
+    const handleResume = useCallback(async (row: Record<string, unknown>) => {
+        const suiteId = row.id as number;
+        setResumingId(suiteId);
+        try {
+            const result = await triggerResume(suiteId).unwrap();
+            const genId = result.data.id;
+            const currentStep = (result.data.wizard_snapshot?.currentStep as number) ?? 1;
+            const tabValue = STEP_TAB_MAP[currentStep] ?? "create_generation";
+            insertData(genId, "sim_gen_id", LocalStorage, false);
+            navigate(`/sim-studio/create?simStudioTab=${tabValue}`);
+        } catch {
+            toast.error("Failed to resume simulation suite. Please try again.");
+        } finally {
+            setResumingId(null);
+        }
+    }, [triggerResume, navigate, STEP_TAB_MAP]);
+
     const columns: TableColumn[] = useMemo(() => [
         {
             label: "Suite Name",
@@ -145,13 +175,20 @@ const useSimStudioController = () => {
             label: "Actions",
             key: "actions",
             render: (row: Record<string, unknown>) => (
-                <SimStudioActions onView={() => handleView(row)} />
+                <SimStudioActions
+                    onView={() => handleView(row)}
+                    onResume={() => void handleResume(row)}
+                    isDraft={(row.status as string) === "DRAFT"}
+                    isResuming={resumingId === (row.id as number)}
+                />
             ),
         },
-    ], [handleView]);
+    ], [handleView, handleResume, resumingId]);
 
     const handleCreate = () => {
-        navigate("/sim-studio/create");
+        removeData("sim_gen_id", LocalStorage);
+        removeData("sim_suite_id", LocalStorage);
+        navigate("/sim-studio/create?simStudioTab=create_generation");
     };
 
     const pagination = useMemo(() => ({

--- a/frontend/src/redux/Api/SimStudio/index.ts
+++ b/frontend/src/redux/Api/SimStudio/index.ts
@@ -3,6 +3,11 @@ import { getAuthToken } from "../../../utils/Common/storage";
 
 const BASE_URL = import.meta.env.VITE_API_URL as string;
 
+export interface FakerSemanticItem {
+    id: string;
+    name: string;
+}
+
 export interface CreateSuitePayload {
     name: string;
     description?: string;
@@ -47,6 +52,7 @@ export interface FieldStrategy {
     static_value?: unknown;
     range_min?: number;
     range_max?: number;
+    faker_semantic_type?: string;
     generator_type?: string;
     generator_options?: Record<string, unknown>;
     is_required_override?: boolean;
@@ -58,6 +64,7 @@ export interface UpsertFieldStrategyItem {
     static_value?: unknown;
     range_min?: number;
     range_max?: number;
+    faker_semantic_type?: string;
     generator_type?: string;
     generator_options?: Record<string, unknown>;
     is_required_override?: boolean;
@@ -79,6 +86,7 @@ export interface TriggerFieldOverride {
     static_value?: unknown;
     range_min?: number;
     range_max?: number;
+    faker_semantic_type?: string;
     generator_type?: string;
     generator_options?: Record<string, unknown>;
     created_at: string;
@@ -107,6 +115,7 @@ export interface BulkTriggerConfigItem {
         static_value?: unknown;
         range_min?: number;
         range_max?: number;
+        faker_semantic_type?: string;
         generator_type?: string;
         generator_options?: Record<string, unknown>;
     }[];
@@ -124,6 +133,20 @@ export interface SuiteListItem {
     last_run_at?: string;
     updated_at: string;
     created_by: string;
+    wizard_progress: Record<string, unknown>;
+    generation_id?: number;
+}
+
+export interface SuiteDetail {
+    id: number;
+    name: string;
+    description?: string;
+    rule_name?: string;
+    rule_version?: string;
+    rule_config?: Record<string, unknown>;
+    primary_txtp?: string;
+    primary_txtp_version?: string;
+    status: string;
     wizard_progress: Record<string, unknown>;
     generation_id?: number;
 }
@@ -180,6 +203,7 @@ export interface EnrichmentSchemaProperty {
     staticValue: string;
     rangeMin: string;
     rangeMax: string;
+    semanticId?: string;
 }
 
 export interface EnrichmentTableDto {
@@ -354,6 +378,22 @@ export const simStudioApi = createApi({
             query: (generationId) => `generations/${generationId}/summary`,
         }),
 
+        resumeGeneration: builder.query<{
+            success: boolean;
+            data: { id: number; suite_id: number; wizard_snapshot: { currentStep?: number; completedSteps?: number[] } };
+        }, number>({
+            query: (suiteId) => `suites/${suiteId}/generations/resume`,
+        }),
+
+        getSuiteById: builder.query<{ success: boolean; suite: SuiteDetail }, number>({
+            query: (suiteId) => `suites/${suiteId}`,
+        }),
+
+        getFakerSemanticData: builder.query<{ success: boolean; data: FakerSemanticItem[] }, void>({
+            query: () => `${BASE_URL}/faker-semantic-data`,
+            transformResponse: (response: { success: boolean; message?: string; data: FakerSemanticItem[] }) => ({ success: response.success, data: response.data }),
+        }),
+
         updateWizardProgress: builder.mutation<{ success: boolean }, { generationId: number; current_step_num: number; completed_step_num: number }>({
             query: ({ generationId, current_step_num, completed_step_num }) => ({
                 url: `generations/${generationId}/wizard-progress`,
@@ -385,5 +425,8 @@ export const {
     useCreateEnrichmentTableMutation,
     useDeleteEnrichmentTableMutation,
     useGetGenerationSummaryQuery,
+    useLazyResumeGenerationQuery,
+    useLazyGetSuiteByIdQuery,
+    useGetFakerSemanticDataQuery,
     useUpdateWizardProgressMutation,
 } = simStudioApi;

--- a/frontend/src/utils/Constants/data.ts
+++ b/frontend/src/utils/Constants/data.ts
@@ -589,7 +589,7 @@ export const SimulationTabs = [
 ]
 
 export const SimStudioTabs = [
-    { label: 'Rule & Details',      value: 'rule_details',        enabled: false },
+    { label: 'Rule & Details',      value: 'create_generation',   enabled: false },
     { label: 'TXTP Selection',      value: 'txtp_selection',      enabled: false },
     { label: 'Trigger Data',        value: 'trigger_data',        enabled: false },
     { label: 'Enrichment Data',     value: 'enrichment_data',     enabled: false },


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
This pull request introduces a new "faker semantic data" feature to the simulation studio, enabling the retrieval and assignment of semantic types to fields for data generation and enrichment. The changes span backend and frontend, including new API endpoints, DTOs, service logic, and UI enhancements to support semantic type selection for schema fields.

**Backend: Faker Semantic Data API and Integration**

* Added new `FakerSemanticDataModule`, including controller, service, and DTOs to provide an authenticated API endpoint for retrieving faker semantic data. This endpoint is now registered in `app.module.ts`. [[1]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R25) [[2]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R52) [[3]](diffhunk://#diff-26df9ee06e4223959b6be40c0bdd3a9ae85b00a5ce6733dd5897e69a57ed4cb0R1-R20) [[4]](diffhunk://#diff-7597e9015968b77fe629323065fdebb254025b67cfe8ee015ce3bb44c3a0945eR1-R33) [[5]](diffhunk://#diff-e7de300a7424122dcec84ddfcc767b5de9f2c69ade334b6c610cf72fd68efe06R1-R13) [[6]](diffhunk://#diff-515d138f4f0b6e958e4cde0c37eb46a6581d194eef33de3fd9e20d5bb8705a7bR1-R19)
* Extended `AdminServiceClient` with a `generateFakerSemanticData` method and added the corresponding constant for the API route. [[1]](diffhunk://#diff-49694be9498867c5f13f9523a950a3184459e6a59699ed164e063d0df91a468eR66) [[2]](diffhunk://#diff-49694be9498867c5f13f9523a950a3184459e6a59699ed164e063d0df91a468eL639-R644) [[3]](diffhunk://#diff-e9e156d23bf4e82765e23e34d5d56ed65be36964a1cd5fdeadbefd74479dbb5fR87)

**Backend: DTO and Test Updates for Semantic Types**

* Replaced `generator_type` with `faker_semantic_type` in context and trigger TXT config DTOs, and updated related tests to use the new property. [[1]](diffhunk://#diff-6e1d7d2a257eb58a4f995533cd54367c1bc2d3effdcd7912506a45fa0b572ac9L130-R130) [[2]](diffhunk://#diff-6e1d7d2a257eb58a4f995533cd54367c1bc2d3effdcd7912506a45fa0b572ac9L213-R213) [[3]](diffhunk://#diff-e8643f1c7757a24955c54046029328fc6f0ebf9a2941ed59e76d0133694e3d9cL45-R45) [[4]](diffhunk://#diff-e8643f1c7757a24955c54046029328fc6f0ebf9a2941ed59e76d0133694e3d9cL80-R80) [[5]](diffhunk://#diff-6bbb39466d4dc40f6b01a7f5a5b0b09082841b424a8b47a09317b7fb49c0796dL174-R178)
* Added a dedicated test suite for the new `FakerSemanticDataService`, ensuring correct integration and error handling.

**Frontend: Semantic Type Selection UI**

* Updated the enrichment data UI to fetch available semantic types from the backend and allow users to assign a semantic type to each schema field via a new dropdown in the table. This includes passing the semantic options to row components and displaying the selected semantic type. [[1]](diffhunk://#diff-fe4fc453cb860c7181e74660063e2c3aa52d967e17ccf2a3cdb67dbe2c7f99fdR32-R43) [[2]](diffhunk://#diff-fe4fc453cb860c7181e74660063e2c3aa52d967e17ccf2a3cdb67dbe2c7f99fdR117-R130) [[3]](diffhunk://#diff-fe4fc453cb860c7181e74660063e2c3aa52d967e17ccf2a3cdb67dbe2c7f99fdR140-R141) [[4]](diffhunk://#diff-fe4fc453cb860c7181e74660063e2c3aa52d967e17ccf2a3cdb67dbe2c7f99fdR235) [[5]](diffhunk://#diff-fe4fc453cb860c7181e74660063e2c3aa52d967e17ccf2a3cdb67dbe2c7f99fdR262-R268) [[6]](diffhunk://#diff-fe4fc453cb860c7181e74660063e2c3aa52d967e17ccf2a3cdb67dbe2c7f99fdR354-R360) [[7]](diffhunk://#diff-fe4fc453cb860c7181e74660063e2c3aa52d967e17ccf2a3cdb67dbe2c7f99fdR370)

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done