### PR TITLE
fix: rule-only simulation NATS subject generation

### DIFF
--- a/frontend/__tests__/pages/RuleEditor/Simulation/useSimulationController.test.tsx
+++ b/frontend/__tests__/pages/RuleEditor/Simulation/useSimulationController.test.tsx
@@ -600,8 +600,8 @@ describe('useSimulationController', () => {
                     expect.objectContaining({
                         functionName: '',
                         awaitReply: true,
-                        destination: 'sub-rule-config-456@1.0.0',
-                        consumer: 'pub-rule-config-456@1.0.0',
+                        destination: 'sub-config-456@1.0.0',
+                        consumer: 'pub-config-456@1.0.0',
                         message: { test: 'data' },
                     })
                 );

--- a/frontend/src/pages/RuleEditor/Simulation/useSimulationController.tsx
+++ b/frontend/src/pages/RuleEditor/Simulation/useSimulationController.tsx
@@ -326,13 +326,11 @@ const useSimulationController = (props: ISimulation) => {
         if (isReadOnly) {
 
             const rule_config_id = data?.rule_config_id
-            const id = rule_config_id?.toString().split('@')[0]
-            const version = data?.version
             body = {
                 functionName: '',
                 awaitReply: true,
-                destination: `sub-rule-${id}@${version}`,
-                consumer: `pub-rule-${id}@${version}`,
+                destination: `sub-${rule_config_id}`,
+                consumer: `pub-${rule_config_id}`,
                 message: parsedPayload
             };
             mutation = ruleOnly;


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

- Fixed rule-only simulation NATS subject generation in `useSimulationController`.
- Updated the simulation controller to build the `destination` and `consumer` subjects directly from `rule_config_id` instead of reconstructing them from a stripped rule ID and version.
- Updated simulation controller tests to validate the corrected NATS subject format.

## Why are we doing this?

This change ensures rule-only simulations use the correct deployed rule configuration subject format, preventing invalid NATS subjects such as `sub-rule-rule-456@1.0.0` and ensuring messages are routed correctly using the expected `sub-rule-456@1.0.0` format.

## How was it tested?

- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done

**Validation**
- Frontend Jest suite:
  - 162 test suites passed
  - 5,215 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated read-only rule simulations to use the correct destination and consumer configuration identifiers.
  * Preserved existing simulation behavior, including function execution, reply handling, and message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->