### PR TITLE
fix: root version 4.0.0-rc.0 + audit-lib 1.0.9-rc.0 pin for Docker release tags

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,7 +21,7 @@
         "@nestjs/throttler": "^6.5.0",
         "@nestjs/websockets": "^11.1.19",
         "@socket.io/redis-adapter": "^8.3.0",
-        "@tazama-lf/audit-lib": "^1.0.8",
+        "@tazama-lf/audit-lib": "1.0.9-rc.0",
         "@tazama-lf/auth-lib": "4.0.0-rc.5",
         "@tazama-lf/frms-coe-lib": "8.2.0-rc.6",
         "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.8",
@@ -4077,9 +4077,9 @@
       }
     },
     "node_modules/@tazama-lf/audit-lib": {
-      "version": "1.0.8",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/audit-lib/1.0.8/742d2c1f1756f40749ba00b115e00928378e740d",
-      "integrity": "sha512-6cAYCoelZg+3AER6hjhKkL5IpYflflgz/4fkF2DuE4M+xy0Oq953R/swJ+Uvk79fZoAGDACklK+wQ/NprWOnNg==",
+      "version": "1.0.9-rc.0",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/audit-lib/1.0.9-rc.0/501b45ca88254b727fc5f09bc3524e0156199b6b",
+      "integrity": "sha512-q4qjpwrWdzqxXVjhsTrWNuWm4Kirr08YcFXRGxNbsilQ1SGzvkXqGm4qCR4JuOiNnnND2/VmyYA0RoeNjOK+MQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opensearch-project/opensearch": "^3.5.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -40,7 +40,7 @@
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/websockets": "^11.1.19",
     "@socket.io/redis-adapter": "^8.3.0",
-    "@tazama-lf/audit-lib": "^1.0.8",
+    "@tazama-lf/audit-lib": "1.0.9-rc.0",
     "@tazama-lf/auth-lib": "4.0.0-rc.5",
     "@tazama-lf/frms-coe-lib": "8.2.0-rc.6",
     "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.8",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "version": "4.0.0-rc.0",
   "scripts": {
     "lint:eslint": "npm run backend:lint:eslint && npm run frontend:lint:eslint",
     "backend:lint:eslint": "cd backend && npm ci && npm run lint",


### PR DESCRIPTION
# Docker release tags: root version stamp + audit-lib pin

Repo-local half of [#141](https://github.com/tazama-lf/rule-studio/issues/141) (Docker image tag remediation, v4.0.0 Clusters B/G/H). The workflow half already landed: the dual Docker workflows are now sync-stamped caller stubs of the central reusable workflows (tazama-lf/workflows#151, distributed via #142/#143).

## Changes

### 1. Root `package.json`: `"version": "4.0.0-rc.0"`

The reusable dual workflow reads the image version from the ROOT `package.json`, but rule-studio's root manifest had no `version` field at all - release-day images were tagged from the backend sub-package (`4.0.0-rc.0`, never `4.0.0`). Stamped with the in-flight v4.0.0 rc line (per the mid-release decision - no 4.1.0 bump), so the v4.0.0 re-release produces images tagged `4.0.0` + `latest`.

### 2. `backend/`: exact pin `@tazama-lf/audit-lib@1.0.9-rc.0`

`audit-lib@1.0.8` was deleted and republished on GitHub Packages (tarball `742d2c1f` -> `7c1cdc5d`), so `npm ci` against the stale lockfile 409s with "Package file checksum mismatch" (tazama-lf/audit-lib#68). Pinned the exact `1.0.9-rc.0` (published under the `rc` dist-tag) and regenerated the backend lockfile.

## Verification

- `npm ci` in `backend/` succeeds against the regenerated lockfile (1354 packages, no 409).
- Lockfile diff is scoped to the audit-lib entry only (8 lines).
- Merging this PR to `dev` fires the rc caller stub -> central reusable `dockerhub-image-build-dual-rc.yml@dev` - a live test of the stub chain. Watch the run.

## Rollout context

After merge: the v4.0.0 re-release (dev -> main) fires the stable stub (`@v1`, already advanced to 0eabfe4) and rebuilds both images at `4.0.0` + `latest`.

Refs #141
